### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -221,7 +221,7 @@ repositories {
 def versions = [
   junit           : '5.7.2',
   junitPlatform   : '1.7.2',
-  reformLogging   : '5.1.9',
+  reformLogging   : '6.0.1',
   springDoc       : '1.6.6',
   camunda         : '7.14.0',
   pitest          : '1.7.4',


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.