### PR TITLE
RET-4397: Fix for Old Cases missing data

### DIFF
--- a/src/main/resources/wa-task-configuration-employment-et_englandwales.dmn
+++ b/src/main/resources/wa-task-configuration-employment-et_englandwales.dmn
@@ -109,7 +109,6 @@ else caseData.claimantIndType.claimant_first_names + " " + caseData.claimantIndT
 "ET3Processing",
 "ReviewReferralResponseLegalOps",
 "ReviewReferralResponseAdmin",
-"ET3Notification",
 "IssueInitialConsiderationDirections",
 "ReviewRule21Referral",
 "SendEt3Notification"</text>
@@ -674,7 +673,7 @@ else 5000</text>
           <text>if (caseData != null
 and caseData.referralCollection != null
 and count(caseData.referralCollection[count(value.referralReplyCollection)&gt;0])&gt;0
-and sort(flatten(caseData.referralCollection.value.referralReplyCollection), function(x,y) date and time(x.value.replyDateTime) &gt; date and time(y.value.replyDateTime))[1].value.isUrgentReply = "Yes")
+and sort(flatten(caseData.referralCollection.value.referralReplyCollection), function(x,y) date and time(if(x.value.replyDateTime!=null)then x.value.replyDateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.replyDateTime!=null)then y.value.replyDateTime else "2023-01-01T00:00:00.000"))[1].value.isUrgentReply = "Yes")
 then 1000
 else 5000</text>
         </outputEntry>
@@ -753,7 +752,7 @@ else 500</text>
           <text>if (caseData!=null
 and caseData.referralCollection != null
 and count(caseData.referralCollection[count(value.referralReplyCollection)&gt;0])&gt;0
-and sort(flatten(caseData.referralCollection.value.referralReplyCollection), function(x,y) date and time(x.value.replyDateTime) &gt; date and time(y.value.replyDateTime))[1].value.isUrgentReply = "Yes")
+and sort(flatten(caseData.referralCollection.value.referralReplyCollection), function(x,y) date and time(if(x.value.replyDateTime!=null)then x.value.replyDateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.replyDateTime!=null)then y.value.replyDateTime else "2023-01-01T00:00:00.000"))[1].value.isUrgentReply = "Yes")
 then 100
 else 500</text>
         </outputEntry>
@@ -920,7 +919,7 @@ else 2</text>
           <text>if (caseData!=null
 and caseData.referralCollection != null
 and count(caseData.referralCollection[count(value.referralReplyCollection)&gt;0])&gt;0
-and sort(flatten(caseData.referralCollection.value.referralReplyCollection), function(x,y) date and time(x.value.replyDateTime) &gt; date and time(y.value.replyDateTime))[1].value.isUrgentReply = "Yes")
+and sort(flatten(caseData.referralCollection.value.referralReplyCollection), function(x,y) date and time(if(x.value.replyDateTime!=null)then x.value.replyDateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.replyDateTime!=null)then y.value.replyDateTime else "2023-01-01T00:00:00.000"))[1].value.isUrgentReply = "Yes")
 then 1
 else 2</text>
         </outputEntry>

--- a/src/main/resources/wa-task-configuration-employment-et_scotland.dmn
+++ b/src/main/resources/wa-task-configuration-employment-et_scotland.dmn
@@ -109,7 +109,6 @@ else caseData.claimantIndType.claimant_first_names + " " + caseData.claimantIndT
 "ET3Processing",
 "ReviewReferralResponseLegalOps",
 "ReviewReferralResponseAdmin",
-"ET3Notification",
 "IssueInitialConsiderationDirections",
 "ReviewRule21Referral",
 "SendEt3Notification"</text>
@@ -674,7 +673,7 @@ else 5000</text>
           <text>if (caseData!=null
 and caseData.referralCollection != null
 and count(caseData.referralCollection[count(value.referralReplyCollection)&gt;0])&gt;0
-and sort(flatten(caseData.referralCollection.value.referralReplyCollection), function(x,y) date and time(x.value.replyDateTime) &gt; date and time(y.value.replyDateTime))[1].value.isUrgentReply = "Yes")
+and sort(flatten(caseData.referralCollection.value.referralReplyCollection), function(x,y) date and time(if(x.value.replyDateTime!=null)then x.value.replyDateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.replyDateTime!=null)then y.value.replyDateTime else "2023-01-01T00:00:00.000"))[1].value.isUrgentReply = "Yes")
 then 1000
 else 5000</text>
         </outputEntry>
@@ -753,7 +752,7 @@ else 500</text>
           <text>if (caseData!=null
 and caseData.referralCollection != null
 and count(caseData.referralCollection[count(value.referralReplyCollection)&gt;0])&gt;0
-and sort(flatten(caseData.referralCollection.value.referralReplyCollection), function(x,y) date and time(x.value.replyDateTime) &gt; date and time(y.value.replyDateTime))[1].value.isUrgentReply = "Yes")
+and sort(flatten(caseData.referralCollection.value.referralReplyCollection), function(x,y) date and time(if(x.value.replyDateTime!=null)then x.value.replyDateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.replyDateTime!=null)then y.value.replyDateTime else "2023-01-01T00:00:00.000"))[1].value.isUrgentReply = "Yes")
 then 100
 else 500</text>
         </outputEntry>
@@ -920,7 +919,7 @@ else 2</text>
           <text>if (caseData!=null
 and caseData.referralCollection != null
 and count(caseData.referralCollection[count(value.referralReplyCollection)&gt;0])&gt;0
-and sort(flatten(caseData.referralCollection.value.referralReplyCollection), function(x,y) date and time(x.value.replyDateTime) &gt; date and time(y.value.replyDateTime))[1].value.isUrgentReply = "Yes")
+and sort(flatten(caseData.referralCollection.value.referralReplyCollection), function(x,y) date and time(if(x.value.replyDateTime!=null)then x.value.replyDateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.replyDateTime!=null)then y.value.replyDateTime else "2023-01-01T00:00:00.000"))[1].value.isUrgentReply = "Yes")
 then 1
 else 2</text>
         </outputEntry>

--- a/src/main/resources/wa-task-initiation-employment-et_englandwales.dmn
+++ b/src/main/resources/wa-task-initiation-employment-et_englandwales.dmn
@@ -38,7 +38,7 @@ else null</text>
 and additionalData.Data!=null
 and additionalData.Data.referralCollection!=null
 and count(additionalData.Data.referralCollection[count(value.referralReplyCollection)&gt;0])&gt;0)
-then sort(flatten(additionalData.Data.referralCollection[value.referralReplyCollection!=null].value.referralReplyCollection), function(x,y) date and time(x.value.replyDateTime) &gt; date and time(y.value.replyDateTime)).value.directionTo[1]
+then sort(flatten(additionalData.Data.referralCollection[value.referralReplyCollection!=null].value.referralReplyCollection), function(x,y) date and time(if(x.value.replyDateTime!=null)then x.value.replyDateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.replyDateTime!=null)then y.value.replyDateTime else "2023-01-01T00:00:00.000")).value.directionTo[1]
 else null</text>
         </inputExpression>
       </input>
@@ -67,7 +67,7 @@ else null</text>
 and additionalData.Data!=null
 and additionalData.Data.genericTseApplicationCollection!=null
 and count(additionalData.Data.genericTseApplicationCollection[value.respondCollection!=null])&gt;0)
-then sort(flatten(additionalData.Data.genericTseApplicationCollection[value.respondCollection!=null].value.respondCollection), function(x,y) date and time(x.value.dateTime) &gt; date and time(y.value.dateTime))[1].value.from
+then sort(flatten(additionalData.Data.genericTseApplicationCollection[value.respondCollection!=null].value.respondCollection), function(x,y) date and time(if(x.value.dateTime!=null)then x.value.dateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.dateTime!=null)then y.value.dateTime else "2023-01-01T00:00:00.000"))[1].value.from
 else null</text>
         </inputExpression>
       </input>
@@ -77,7 +77,7 @@ else null</text>
 and additionalData.Data!=null
 and additionalData.Data.genericTseApplicationCollection!=null
 and count(additionalData.Data.genericTseApplicationCollection[value.respondCollection!=null])&gt;0)
-then sort(flatten(additionalData.Data.genericTseApplicationCollection[value.respondCollection!=null].value.respondCollection), function(x,y) date and time(x.value.dateTime) &gt; date and time(y.value.dateTime))[1].value.applicationType
+then sort(flatten(additionalData.Data.genericTseApplicationCollection[value.respondCollection!=null].value.respondCollection), function(x,y) date and time(if(x.value.dateTime!=null)then x.value.dateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.dateTime!=null)then y.value.dateTime else "2023-01-01T00:00:00.000"))[1].value.applicationType
 else null</text>
         </inputExpression>
       </input>
@@ -408,7 +408,7 @@ else null</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0qcsldu">
           <text>"Review Referral Response - "
-+ sort(flatten(additionalData.Data.referralCollection[value.referralReplyCollection!=null].value.referralReplyCollection), function(x,y) date and time(x.value.replyDateTime) &gt; date and time(y.value.replyDateTime)).value.referralSubject[1]</text>
++ sort(flatten(additionalData.Data.referralCollection[value.referralReplyCollection!=null].value.referralReplyCollection), function(x,y) date and time(if(x.value.replyDateTime!=null)then x.value.replyDateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.replyDateTime!=null)then y.value.replyDateTime else "2023-01-01T00:00:00.000")).value.referralSubject[1]</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0kmxycv">
           <text></text>
@@ -450,7 +450,7 @@ else null</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_08j7d7p">
           <text>"Review Referral Response - "
-+ sort(flatten(additionalData.Data.referralCollection[value.referralReplyCollection!=null].value.referralReplyCollection), function(x,y) date and time(x.value.replyDateTime) &gt; date and time(y.value.replyDateTime)).value.referralSubject[1]</text>
++ sort(flatten(additionalData.Data.referralCollection[value.referralReplyCollection!=null].value.referralReplyCollection), function(x,y) date and time(if(x.value.replyDateTime!=null)then x.value.replyDateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.replyDateTime!=null)then y.value.replyDateTime else "2023-01-01T00:00:00.000")).value.referralSubject[1]</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0zcsqzi">
           <text></text>
@@ -492,7 +492,7 @@ else null</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_03wz7tv">
           <text>"Review Referral Response - "
-+ sort(flatten(additionalData.Data.referralCollection[value.referralReplyCollection!=null].value.referralReplyCollection), function(x,y) date and time(x.value.replyDateTime) &gt; date and time(y.value.replyDateTime)).value.referralSubject[1]</text>
++ sort(flatten(additionalData.Data.referralCollection[value.referralReplyCollection!=null].value.referralReplyCollection), function(x,y) date and time(if(x.value.replyDateTime!=null)then x.value.replyDateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.replyDateTime!=null)then y.value.replyDateTime else "2023-01-01T00:00:00.000")).value.referralSubject[1]</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_14hvioj">
           <text></text>

--- a/src/main/resources/wa-task-initiation-employment-et_scotland.dmn
+++ b/src/main/resources/wa-task-initiation-employment-et_scotland.dmn
@@ -38,7 +38,7 @@ else null</text>
 and additionalData.Data!=null
 and additionalData.Data.referralCollection!=null
 and count(additionalData.Data.referralCollection[count(value.referralReplyCollection)&gt;0])&gt;0)
-then sort(flatten(additionalData.Data.referralCollection[value.referralReplyCollection!=null].value.referralReplyCollection), function(x,y) date and time(x.value.replyDateTime) &gt; date and time(y.value.replyDateTime)).value.directionTo[1]
+then sort(flatten(additionalData.Data.referralCollection[value.referralReplyCollection!=null].value.referralReplyCollection), function(x,y) date and time(if(x.value.replyDateTime!=null)then x.value.replyDateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.replyDateTime!=null)then y.value.replyDateTime else "2023-01-01T00:00:00.000")).value.directionTo[1]
 else null</text>
         </inputExpression>
       </input>
@@ -67,7 +67,7 @@ else null</text>
 and additionalData.Data!=null
 and additionalData.Data.genericTseApplicationCollection!=null
 and count(additionalData.Data.genericTseApplicationCollection[value.respondCollection!=null])&gt;0)
-then sort(flatten(additionalData.Data.genericTseApplicationCollection[value.respondCollection!=null].value.respondCollection), function(x,y) date and time(x.value.dateTime) &gt; date and time(y.value.dateTime))[1].value.from
+then sort(flatten(additionalData.Data.genericTseApplicationCollection[value.respondCollection!=null].value.respondCollection), function(x,y) date and time(if(x.value.dateTime!=null)then x.value.dateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.dateTime!=null)then y.value.dateTime else "2023-01-01T00:00:00.000"))[1].value.from
 else null</text>
         </inputExpression>
       </input>
@@ -77,7 +77,7 @@ else null</text>
 and additionalData.Data!=null
 and additionalData.Data.genericTseApplicationCollection!=null
 and count(additionalData.Data.genericTseApplicationCollection[value.respondCollection!=null])&gt;0)
-then sort(flatten(additionalData.Data.genericTseApplicationCollection[value.respondCollection!=null].value.respondCollection), function(x,y) date and time(x.value.dateTime) &gt; date and time(y.value.dateTime))[1].value.applicationType
+then sort(flatten(additionalData.Data.genericTseApplicationCollection[value.respondCollection!=null].value.respondCollection), function(x,y) date and time(if(x.value.dateTime!=null)then x.value.dateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.dateTime!=null)then y.value.dateTime else "2023-01-01T00:00:00.000"))[1].value.applicationType
 else null</text>
         </inputExpression>
       </input>
@@ -408,7 +408,7 @@ else null</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0qcsldu">
           <text>"Review Referral Response - "
-+ sort(flatten(additionalData.Data.referralCollection[value.referralReplyCollection!=null].value.referralReplyCollection), function(x,y) date and time(x.value.replyDateTime) &gt; date and time(y.value.replyDateTime)).value.referralSubject[1]</text>
++ sort(flatten(additionalData.Data.referralCollection[value.referralReplyCollection!=null].value.referralReplyCollection), function(x,y) date and time(if(x.value.replyDateTime!=null)then x.value.replyDateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.replyDateTime!=null)then y.value.replyDateTime else "2023-01-01T00:00:00.000")).value.referralSubject[1]</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0kmxycv">
           <text></text>
@@ -450,7 +450,7 @@ else null</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_08j7d7p">
           <text>"Review Referral Response - "
-+ sort(flatten(additionalData.Data.referralCollection[value.referralReplyCollection!=null].value.referralReplyCollection), function(x,y) date and time(x.value.replyDateTime) &gt; date and time(y.value.replyDateTime)).value.referralSubject[1]</text>
++ sort(flatten(additionalData.Data.referralCollection[value.referralReplyCollection!=null].value.referralReplyCollection), function(x,y) date and time(if(x.value.replyDateTime!=null)then x.value.replyDateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.replyDateTime!=null)then y.value.replyDateTime else "2023-01-01T00:00:00.000")).value.referralSubject[1]</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0zcsqzi">
           <text></text>
@@ -492,7 +492,7 @@ else null</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_03wz7tv">
           <text>"Review Referral Response - "
-+ sort(flatten(additionalData.Data.referralCollection[value.referralReplyCollection!=null].value.referralReplyCollection), function(x,y) date and time(x.value.replyDateTime) &gt; date and time(y.value.replyDateTime)).value.referralSubject[1]</text>
++ sort(flatten(additionalData.Data.referralCollection[value.referralReplyCollection!=null].value.referralReplyCollection), function(x,y) date and time(if(x.value.replyDateTime!=null)then x.value.replyDateTime else "2023-01-01T00:00:00.000") &gt; date and time(if(y.value.replyDateTime!=null)then y.value.replyDateTime else "2023-01-01T00:00:00.000")).value.referralSubject[1]</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_14hvioj">
           <text></text>

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskConfigurationTestEW.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskConfigurationTestEW.java
@@ -260,7 +260,6 @@ class EmploymentTaskConfigurationTestEW extends DmnDecisionTableBaseUnitTest {
             Arguments.of("ET3Processing", routineWork),
             Arguments.of("ReviewReferralResponseLegalOps", routineWork),
             Arguments.of("ReviewReferralResponseAdmin", routineWork),
-            Arguments.of("ET3Notification", routineWork),
             Arguments.of("IssueInitialConsiderationDirections", routineWork),
 
             Arguments.of("ReviewReferralJudiciary", decisionMakingWork),

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskConfigurationTestScot.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskConfigurationTestScot.java
@@ -259,7 +259,6 @@ class EmploymentTaskConfigurationTestScot extends DmnDecisionTableBaseUnitTest {
             Arguments.of("ET3Processing", routineWork),
             Arguments.of("ReviewReferralResponseLegalOps", routineWork),
             Arguments.of("ReviewReferralResponseAdmin", routineWork),
-            Arguments.of("ET3Notification", routineWork),
             Arguments.of("IssueInitialConsiderationDirections", routineWork),
 
             Arguments.of("ReviewReferralJudiciary", decisionMakingWork),

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestEW.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestEW.java
@@ -461,7 +461,7 @@ class EmploymentTaskInitiationTestEW extends DmnDecisionTableBaseUnitTest {
 
     private static String createApplications(String applicationType, String respondFrom) {
         String respondCollection = "";
-        if (!"".equals(respondFrom)) {
+        if (!respondFrom.isEmpty()) {
             respondCollection = String.format(RESPOND_COLLECTION, applicationType, respondFrom);
         }
 
@@ -478,7 +478,7 @@ class EmploymentTaskInitiationTestEW extends DmnDecisionTableBaseUnitTest {
 
         String replyCollection1 = "";
         String replyCollection2 = "";
-        if (!"".equals(referralDirectionTo)) {
+        if (!referralDirectionTo.isEmpty()) {
             LocalDateTime now = LocalDateTime.now();
             String reply1 = String.format(REFERRALREPLY,
                                           referralSubject1,

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestScot.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestScot.java
@@ -461,7 +461,7 @@ class EmploymentTaskInitiationTestScot extends DmnDecisionTableBaseUnitTest {
 
     private static String createApplications(String applicationType, String respondFrom) {
         String respondCollection = "";
-        if (!"".equals(respondFrom)) {
+        if (!respondFrom.isEmpty()) {
             respondCollection = String.format(RESPOND_COLLECTION, applicationType, respondFrom);
         }
 
@@ -478,7 +478,7 @@ class EmploymentTaskInitiationTestScot extends DmnDecisionTableBaseUnitTest {
 
         String replyCollection1 = "";
         String replyCollection2 = "";
-        if (!"".equals(referralDirectionTo)) {
+        if (!referralDirectionTo.isEmpty()) {
             LocalDateTime now = LocalDateTime.now();
             String reply1 = String.format(REFERRALREPLY,
                                           referralSubject1,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-4397

### Change description ###
Old cases may have ReferralReplies/ApplicationReplies without data in the new datetime fields used for sorting Replies.
Update configs to replace the null with an old date for sorting purposes

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
