### PR TITLE
Ret-4620-Update to Permissions DMN

### DIFF
--- a/src/main/resources/wa-task-permissions-employment-et_englandwales.dmn
+++ b/src/main/resources/wa-task-permissions-employment-et_englandwales.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition-et_englandwales" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.16.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition-et_englandwales" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.18.0">
   <decision id="wa-task-permissions-employment-et_englandwales" name="ET Task permissions DMN">
     <decisionTable id="DecisionTable_1pr5oic" hitPolicy="RULE ORDER">
       <input id="InputClause_12crj6e" label="Task Type" biodi:width="420" camunda:inputVariable="taskType">
@@ -68,7 +68,7 @@
           <text>"specific-access-approver-judiciary"	</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0ekjswr">
-          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn"</text>
+          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn, Assign, Unassign"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1tlohef">
           <text>"JUDICIAL"</text>
@@ -119,10 +119,7 @@
       <rule id="DecisionRule_0rcls0x">
         <description>Leadership Judge Permissions</description>
         <inputEntry id="UnaryTests_1m23iq2">
-          <text>"ReviewReferralJudiciary",
-"ReviewReferralResponseJudiciary",
-"CompleteInitialConsideration",
-"DraftAndSignJudgment"</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1dkwh9q">
           <text></text>
@@ -134,7 +131,7 @@
           <text>"leadership-judge"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0lzkacj">
-          <text>"Read, Own, Manage, Claim, Assign, Unassign, Complete, Cancel"</text>
+          <text>"Read, Execute, Manage, Claim, Assign, Unassign, Complete, Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0ultxtd">
           <text>"JUDICIAL"</text>
@@ -182,39 +179,6 @@
           <text>false</text>
         </outputEntry>
       </rule>
-      <rule id="DecisionRule_1aggpr7">
-        <description>Fee-Paid Judge  Permissions</description>
-        <inputEntry id="UnaryTests_0dt9jgy">
-          <text>"ReviewReferralJudiciary",
-"ReviewReferralResponseJudiciary",
-"CompleteInitialConsideration",
-"DraftAndSignJudgment"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1nkl5kf">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1rhghee">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0kuhbz9">
-          <text>"fee-paid-judge"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0xsafx0">
-          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1cn38wo">
-          <text>"JUDICIAL"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1upide3">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1k3lw5w">
-          <text>3</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0bh71eh">
-          <text>false</text>
-        </outputEntry>
-      </rule>
       <rule id="DecisionRule_1tvtlre">
         <description>Access Request for Legal Caseworker</description>
         <inputEntry id="UnaryTests_13ukkz6">
@@ -230,7 +194,7 @@
           <text>"specific-access-approver-legal-ops"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_151ry1h">
-          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn"</text>
+          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn, Assign, Unassign"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1rwokl1">
           <text>"LEGAL_OPERATIONS"</text>
@@ -355,7 +319,7 @@
           <text>"specific-access-approver-admin"	</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_18uxrkl">
-          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn"</text>
+          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn, Assign, Unassign"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0fbgbzp">
           <text>"ADMIN"</text>
@@ -575,7 +539,7 @@
           <text>"specific-access-approver-ctsc"	</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1n6hq4e">
-          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn"</text>
+          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn, Assign, Unassign"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0pti6xc">
           <text>"CTSC"</text>

--- a/src/main/resources/wa-task-permissions-employment-et_scotland.dmn
+++ b/src/main/resources/wa-task-permissions-employment-et_scotland.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition-et_scotland" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.16.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-permissions-definition-et_scotland" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.18.0">
   <decision id="wa-task-permissions-employment-et_scotland" name="ET Task permissions DMN">
     <decisionTable id="DecisionTable_1pr5oic" hitPolicy="RULE ORDER">
       <input id="InputClause_12crj6e" label="Task Type" biodi:width="551" camunda:inputVariable="taskType">
@@ -68,7 +68,7 @@
           <text>"specific-access-approver-judiciary"	</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0ekjswr">
-          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn"</text>
+          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn, Assign, Unassign"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1tlohef">
           <text>"JUDICIAL"</text>
@@ -119,10 +119,7 @@
       <rule id="DecisionRule_0rcls0x">
         <description>Leadership Judge Permissions</description>
         <inputEntry id="UnaryTests_1m23iq2">
-          <text>"ReviewReferralJudiciary",
-"ReviewReferralResponseJudiciary",
-"CompleteInitialConsideration",
-"DraftAndSignJudgment"</text>
+          <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1dkwh9q">
           <text></text>
@@ -134,7 +131,7 @@
           <text>"leadership-judge"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0lzkacj">
-          <text>"Read, Own, Manage, Claim, Assign, Unassign, Complete, Cancel"</text>
+          <text>"Read, Execute, Manage, Claim, Assign, Unassign, Complete, Cancel"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0ultxtd">
           <text>"JUDICIAL"</text>
@@ -182,39 +179,6 @@
           <text>false</text>
         </outputEntry>
       </rule>
-      <rule id="DecisionRule_1aggpr7">
-        <description>Fee-Paid Judge  Permissions</description>
-        <inputEntry id="UnaryTests_0dt9jgy">
-          <text>"ReviewReferralJudiciary",
-"ReviewReferralResponseJudiciary",
-"CompleteInitialConsideration",
-"DraftAndSignJudgment"</text>
-        </inputEntry>
-        <inputEntry id="UnaryTests_1nkl5kf">
-          <text></text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_1rhghee">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0kuhbz9">
-          <text>"fee-paid-judge"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0xsafx0">
-          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1cn38wo">
-          <text>"JUDICIAL"</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1upide3">
-          <text></text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_1k3lw5w">
-          <text>3</text>
-        </outputEntry>
-        <outputEntry id="LiteralExpression_0bh71eh">
-          <text>false</text>
-        </outputEntry>
-      </rule>
       <rule id="DecisionRule_1tvtlre">
         <description>Access Request for Legal Caseworker </description>
         <inputEntry id="UnaryTests_13ukkz6">
@@ -230,7 +194,7 @@
           <text>"specific-access-approver-legal-ops"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_151ry1h">
-          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn"</text>
+          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn, Assign, Unassign"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1rwokl1">
           <text>"LEGAL_OPERATIONS"</text>
@@ -355,7 +319,7 @@
           <text>"specific-access-approver-admin"	</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_18uxrkl">
-          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn"</text>
+          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn, Assign, Unassign"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0fbgbzp">
           <text>"ADMIN"</text>
@@ -575,7 +539,7 @@
           <text>"specific-access-approver-ctsc"	</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1n6hq4e">
-          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn"</text>
+          <text>"Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn, Assign, Unassign"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0pti6xc">
           <text>"CTSC"</text>

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskPermissionsTestEW.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskPermissionsTestEW.java
@@ -37,7 +37,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
         "autoAssignable", false,
         "name", "specific-access-approver-judiciary",
         "roleCategory", "JUDICIAL",
-        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn"
+        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn, Assign, Unassign"
     );
     private static final Map<String, Serializable> hearingJudge = Map.of(
         "autoAssignable", true,
@@ -50,7 +50,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
         "autoAssignable", false,
         "assignmentPriority", 4,
         "name", "leadership-judge",
-        "value", "Read, Own, Manage, Claim, Assign, Unassign, Complete, Cancel",
+        "value", "Read, Execute, Manage, Claim, Assign, Unassign, Complete, Cancel",
         "roleCategory", "JUDICIAL"
     );
     private static final Map<String, Serializable> judge = Map.of(
@@ -60,18 +60,11 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
         "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn",
         "roleCategory", "JUDICIAL"
     );
-    private static final Map<String, Serializable> feePaidJudge = Map.of(
-        "autoAssignable", false,
-        "assignmentPriority", 3,
-        "name", "fee-paid-judge",
-        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn",
-        "roleCategory", "JUDICIAL"
-    );
 
     private static final Map<String, Serializable> approverLegalOps = Map.of(
         "autoAssignable", false,
         "name", "specific-access-approver-legal-ops",
-        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn",
+        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn, Assign, Unassign",
         "roleCategory", "LEGAL_OPERATIONS"
     );
     private static final Map<String, Serializable> allocatedTribunalCaseworker = Map.of(
@@ -99,7 +92,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
     private static final Map<String, Serializable> approverAdmin = Map.of(
         "autoAssignable", false,
         "name", "specific-access-approver-admin",
-        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn",
+        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn, Assign, Unassign",
         "roleCategory", "ADMIN"
     );
     private static final Map<String, Serializable> allocatedAdminCaseworker = Map.of(
@@ -141,7 +134,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
     private static final Map<String, Serializable> approverCTSC = Map.of(
         "autoAssignable", true,
         "name", "specific-access-approver-ctsc",
-        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn",
+        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn, Assign, Unassign",
         "roleCategory", "CTSC"
     );
     private static final Map<String, Serializable> allocatedCtscCaseworker = Map.of(
@@ -177,7 +170,8 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "reviewSpecificAccessRequestJudiciary",
                 List.of(
                     taskSupervisor,
-                    approverJudiciary
+                    approverJudiciary,
+                    leadershipJudge
                 )
             ),
             Arguments.of(
@@ -186,8 +180,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                     taskSupervisor,
                     hearingJudge,
                     leadershipJudge,
-                    judge,
-                    feePaidJudge
+                    judge
                 )
             ),
             Arguments.of(
@@ -196,8 +189,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                     taskSupervisor,
                     hearingJudge,
                     leadershipJudge,
-                    judge,
-                    feePaidJudge
+                    judge
                 )
             ),
             Arguments.of(
@@ -206,8 +198,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                     taskSupervisor,
                     hearingJudge,
                     leadershipJudge,
-                    judge,
-                    feePaidJudge
+                    judge
                 )
             ),
             Arguments.of(
@@ -216,8 +207,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                     taskSupervisor,
                     hearingJudge,
                     leadershipJudge,
-                    judge,
-                    feePaidJudge
+                    judge
                 )
             ),
 
@@ -225,13 +215,17 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "reviewSpecificAccessRequestLegalOps",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     approverLegalOps
+                    
+                    
                 )
             ),
             Arguments.of(
                 "ReviewReferralLegalOps",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedTribunalCaseworker,
                     seniorTribunalCaseworker,
                     tribunalCaseworker
@@ -241,6 +235,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "ReviewReferralResponseLegalOps",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedTribunalCaseworker,
                     seniorTribunalCaseworker,
                     tribunalCaseworker
@@ -250,6 +245,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "ReviewRule21Referral",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedTribunalCaseworker,
                     seniorTribunalCaseworker,
                     tribunalCaseworker
@@ -260,6 +256,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "reviewSpecificAccessRequestAdmin",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     approverAdmin
                 )
             ),
@@ -267,6 +264,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "Et1Vetting",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin,
@@ -279,6 +277,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "ReviewReferralAdmin",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin,
@@ -291,6 +290,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "ReviewReferralResponseAdmin",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin,
@@ -303,6 +303,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "SendEt1Notification",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin,
@@ -315,6 +316,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "ListServeClaim",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin,
@@ -327,6 +329,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "ET3Processing",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -336,6 +339,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "SendEt3Notification",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -345,6 +349,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "ListAHearing",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin,
@@ -356,6 +361,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "IssueInitialConsiderationDirections",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -365,6 +371,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "IssuePostHearingDirection",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -374,6 +381,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "IssueJudgment",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -383,6 +391,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "AmendClaimantDetails",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -392,6 +401,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "AmendRespondentDetails",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -401,6 +411,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "WithdrawAllOrPartOfCase",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -410,6 +421,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "ContactTribunalWithAnApplication",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -420,6 +432,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
                 "reviewSpecificAccessRequestCTSC",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     approverCTSC
                 )
             )
@@ -465,7 +478,7 @@ class EmploymentTaskPermissionsTestEW extends DmnDecisionTableBaseUnitTest {
         assertThat(logic.getOutputs().size(), is(7));
         assertThatOutputContainInOrder(outputColumnIds, logic.getOutputs());
         //Rules
-        assertThat(logic.getRules().size(), is(20));
+        assertThat(logic.getRules().size(), is(19));
     }
 
     private void assertThatInputContainInOrder(List<String> inputColumnIds, List<DmnDecisionTableInputImpl> inputs) {

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskPermissionsTestScot.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskPermissionsTestScot.java
@@ -37,7 +37,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
         "autoAssignable", false,
         "name", "specific-access-approver-judiciary",
         "roleCategory", "JUDICIAL",
-        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn"
+        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn, Assign, Unassign"
     );
     private static final Map<String, Serializable> hearingJudge = Map.of(
         "autoAssignable", true,
@@ -50,7 +50,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
         "autoAssignable", false,
         "assignmentPriority", 4,
         "name", "leadership-judge",
-        "value", "Read, Own, Manage, Claim, Assign, Unassign, Complete, Cancel",
+        "value", "Read, Execute, Manage, Claim, Assign, Unassign, Complete, Cancel",
         "roleCategory", "JUDICIAL"
     );
     private static final Map<String, Serializable> judge = Map.of(
@@ -60,18 +60,10 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
         "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn",
         "roleCategory", "JUDICIAL"
     );
-    private static final Map<String, Serializable> feePaidJudge = Map.of(
-        "autoAssignable", false,
-        "assignmentPriority", 3,
-        "name", "fee-paid-judge",
-        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn",
-        "roleCategory", "JUDICIAL"
-    );
-
     private static final Map<String, Serializable> approverLegalOps = Map.of(
         "autoAssignable", false,
         "name", "specific-access-approver-legal-ops",
-        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn",
+        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn, Assign, Unassign",
         "roleCategory", "LEGAL_OPERATIONS"
     );
     private static final Map<String, Serializable> allocatedTribunalCaseworker = Map.of(
@@ -99,7 +91,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
     private static final Map<String, Serializable> approverAdmin = Map.of(
         "autoAssignable", false,
         "name", "specific-access-approver-admin",
-        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn",
+        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn, Assign, Unassign",
         "roleCategory", "ADMIN"
     );
     private static final Map<String, Serializable> allocatedAdminCaseworker = Map.of(
@@ -141,7 +133,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
     private static final Map<String, Serializable> approverCTSC = Map.of(
         "autoAssignable", true,
         "name", "specific-access-approver-ctsc",
-        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn",
+        "value", "Read, Own, Manage, Claim, Unclaim, UnclaimAssign, CompleteOwn, CancelOwn, Assign, Unassign",
         "roleCategory", "CTSC"
     );
     private static final Map<String, Serializable> allocatedCtscCaseworker = Map.of(
@@ -177,7 +169,8 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "reviewSpecificAccessRequestJudiciary",
                 List.of(
                     taskSupervisor,
-                    approverJudiciary
+                    approverJudiciary,
+                    leadershipJudge
                 )
             ),
             Arguments.of(
@@ -186,8 +179,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                     taskSupervisor,
                     hearingJudge,
                     leadershipJudge,
-                    judge,
-                    feePaidJudge
+                    judge
                 )
             ),
             Arguments.of(
@@ -196,8 +188,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                     taskSupervisor,
                     hearingJudge,
                     leadershipJudge,
-                    judge,
-                    feePaidJudge
+                    judge
                 )
             ),
             Arguments.of(
@@ -206,8 +197,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                     taskSupervisor,
                     hearingJudge,
                     leadershipJudge,
-                    judge,
-                    feePaidJudge
+                    judge
                 )
             ),
             Arguments.of(
@@ -216,8 +206,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                     taskSupervisor,
                     hearingJudge,
                     leadershipJudge,
-                    judge,
-                    feePaidJudge
+                    judge
                 )
             ),
 
@@ -225,6 +214,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "reviewSpecificAccessRequestLegalOps",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     approverLegalOps
                 )
             ),
@@ -232,6 +222,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "ReviewReferralLegalOps",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedTribunalCaseworker,
                     seniorTribunalCaseworker,
                     tribunalCaseworker
@@ -241,6 +232,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "ReviewReferralResponseLegalOps",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedTribunalCaseworker,
                     seniorTribunalCaseworker,
                     tribunalCaseworker
@@ -250,6 +242,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "ReviewRule21Referral",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedTribunalCaseworker,
                     seniorTribunalCaseworker,
                     tribunalCaseworker
@@ -260,6 +253,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "reviewSpecificAccessRequestAdmin",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     approverAdmin
                 )
             ),
@@ -267,6 +261,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "Et1Vetting",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin,
@@ -279,6 +274,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "ReviewReferralAdmin",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin,
@@ -291,6 +287,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "ReviewReferralResponseAdmin",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin,
@@ -303,6 +300,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "SendEt1Notification",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin,
@@ -315,6 +313,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "ListServeClaim",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin,
@@ -327,6 +326,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "ET3Processing",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -336,6 +336,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "SendEt3Notification",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -345,6 +346,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "ListAHearing",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin,
@@ -356,6 +358,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "IssueInitialConsiderationDirections",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -365,6 +368,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "IssuePostHearingDirection",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -374,6 +378,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "IssueJudgment",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -383,6 +388,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "AmendClaimantDetails",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -392,6 +398,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "AmendRespondentDetails",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -401,6 +408,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "WithdrawAllOrPartOfCase",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -410,6 +418,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "ContactTribunalWithAnApplication",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     allocatedAdminCaseworker,
                     hearingCentreTeamLeader,
                     hearingCentreAdmin
@@ -420,6 +429,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
                 "reviewSpecificAccessRequestCTSC",
                 List.of(
                     taskSupervisor,
+                    leadershipJudge,
                     approverCTSC
                 )
             )
@@ -465,7 +475,7 @@ class EmploymentTaskPermissionsTestScot extends DmnDecisionTableBaseUnitTest {
         assertThat(logic.getOutputs().size(), is(7));
         assertThatOutputContainInOrder(outputColumnIds, logic.getOutputs());
         //Rules
-        assertThat(logic.getRules().size(), is(20));
+        assertThat(logic.getRules().size(), is(19));
     }
 
     private void assertThatInputContainInOrder(List<String> inputColumnIds, List<DmnDecisionTableInputImpl> inputs) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-4620


### Change description ###
1. Update to Row 2, 7, 11 and 17 - Update permissions to include Assign and Unassign permission
2. Removal of Row 6 - Remove row 6 as fee-paid-judges role CANNOT have permissions given directly 
3. Update to Row 4 - Remove all task type associated with role and in 'Value' column remove 'Own' permission and replace with 'Execute' 



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
