### PR TITLE
RET-4795: Vacated is a valid entry for Hearings

### DIFF
--- a/src/main/resources/wa-task-initiation-employment-et_englandwales.dmn
+++ b/src/main/resources/wa-task-initiation-employment-et_englandwales.dmn
@@ -124,7 +124,8 @@ else null</text>
 and additionalData.Data!=null
 and additionalData.Data.hearingDetailsCollection!=null
 and count(additionalData.Data.hearingDetailsCollection)&gt;0
-and (every x in additionalData.Data.hearingDetailsCollection satisfies x.value.hearingDetailsStatus ="Heard")</text>
+and (some x in additionalData.Data.hearingDetailsCollection satisfies x.value.hearingDetailsStatus="Heard")
+and (every x in additionalData.Data.hearingDetailsCollection satisfies (x.value.hearingDetailsStatus="Heard" or x.value.hearingDetailsStatus="Vacated"))</text>
         </inputExpression>
       </input>
       <input id="InputClause_0z98r1i" label="Submission Reason (Application)" biodi:width="358">

--- a/src/main/resources/wa-task-initiation-employment-et_scotland.dmn
+++ b/src/main/resources/wa-task-initiation-employment-et_scotland.dmn
@@ -124,7 +124,8 @@ else null</text>
 and additionalData.Data!=null
 and additionalData.Data.hearingDetailsCollection!=null
 and count(additionalData.Data.hearingDetailsCollection)&gt;0
-and (every x in additionalData.Data.hearingDetailsCollection satisfies x.value.hearingDetailsStatus ="Heard")</text>
+and (some x in additionalData.Data.hearingDetailsCollection satisfies x.value.hearingDetailsStatus="Heard")
+and (every x in additionalData.Data.hearingDetailsCollection satisfies (x.value.hearingDetailsStatus="Heard" or x.value.hearingDetailsStatus="Vacated"))</text>
         </inputExpression>
       </input>
       <input id="InputClause_0z98r1i" label="Submission Reason (Application)" biodi:width="313">

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestEW.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestEW.java
@@ -99,9 +99,12 @@ class EmploymentTaskInitiationTestEW extends DmnDecisionTableBaseUnitTest {
             + "\"etICRule27ClaimToBe\": \"Dismissed in full\""
             + "}";
 
-    public static final String HEARING_DETAIL_COLLECTION_HEARD =
-        "\"hearingDetailsCollection\": [{\"value\": {\"hearingDetailsStatus\": \"Heard\"}}]";
-    public static final String HEARING_DETAIL_COLLECTION_VACATED =
+    public static final String HEARING_DETAIL_COLLECTION_HEARD_VACATED =
+        "\"hearingDetailsCollection\": ["
+            + "{\"value\": {\"hearingDetailsStatus\": \"Heard\"}},"
+            + "{\"value\": {\"hearingDetailsStatus\": \"Vacated\"}}"
+            + "]";
+    public static final String HEARING_DETAIL_COLLECTION_VACATED_ONLY =
         "\"hearingDetailsCollection\": [{\"value\": {\"hearingDetailsStatus\": \"Vacated\"}}]";
 
     public static final String SUBMISSION_REASON_CLAIMANT_AMEND =
@@ -476,7 +479,7 @@ class EmploymentTaskInitiationTestEW extends DmnDecisionTableBaseUnitTest {
             Arguments.of(
                 "updateHearing",
                 "Accepted",
-                HelperService.mapAdditionalData(HEARING_DETAIL_COLLECTION_HEARD),
+                HelperService.mapAdditionalData(HEARING_DETAIL_COLLECTION_HEARD_VACATED),
                 List.of(
                     HelperService.mapExpectedOutput(
                         "DraftAndSignJudgment",
@@ -488,7 +491,7 @@ class EmploymentTaskInitiationTestEW extends DmnDecisionTableBaseUnitTest {
             Arguments.of(
                 "updateHearing",
                 "Accepted",
-                HelperService.mapAdditionalData(HEARING_DETAIL_COLLECTION_VACATED),
+                HelperService.mapAdditionalData(HEARING_DETAIL_COLLECTION_VACATED_ONLY),
                 List.of()
             ),
             Arguments.of(

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestScot.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestScot.java
@@ -108,8 +108,8 @@ class EmploymentTaskInitiationTestScot extends DmnDecisionTableBaseUnitTest {
     public static final String HEARING_DETAIL_COLLECTION_POSTPONED =
         "\"hearingDetailsCollection\": ["
             + "{\"value\": {\"hearingDetailsStatus\": \"Heard\"}},"
-            + "{\"value\": {\"hearingDetailsStatus\": \"Postponed\"}}" +
-            "]";
+            + "{\"value\": {\"hearingDetailsStatus\": \"Postponed\"}}"
+            + "]";
 
     public static final String SUBMISSION_REASON_CLAIMANT_AMEND =
             HelperService.createApplications("Amend my claim", "");
@@ -591,6 +591,18 @@ class EmploymentTaskInitiationTestScot extends DmnDecisionTableBaseUnitTest {
                         "ContactTribunalWithAnApplication",
                         "Contact the tribunal Response",
                         "Application"
+                    )
+                )
+            ),
+            Arguments.of(
+                "SUBMIT_CLAIMANT_TSE",
+                null,
+                HelperService.mapAdditionalData(SUBMISSION_REASON_CLAIMANT_PERSONALDETAILS),
+                List.of(
+                    HelperService.mapExpectedOutput(
+                        "AmendClaimantDetails",
+                        "Amend Party Details",
+                        "Amendments"
                     )
                 )
             ),

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestScot.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestScot.java
@@ -99,12 +99,17 @@ class EmploymentTaskInitiationTestScot extends DmnDecisionTableBaseUnitTest {
             + "\"etICRule27ClaimToBe\": \"Dismissed in full\""
             + "}";
 
-    public static final String HEARING_DETAIL_COLLECTION_HEARD =
-        "\"hearingDetailsCollection\": [{\"value\": {\"hearingDetailsStatus\": \"Heard\"}},"
-            + "{\"value\": {\"hearingDetailsStatus\": \"Heard\"}}]";
+    public static final String HEARING_DETAIL_COLLECTION_HEARD_VACATED =
+        "\"hearingDetailsCollection\": ["
+            + "{\"value\": {\"hearingDetailsStatus\": \"Heard\"}},"
+            + "{\"value\": {\"hearingDetailsStatus\": \"Heard\"}},"
+            + "{\"value\": {\"hearingDetailsStatus\": \"Vacated\"}}"
+            + "]";
     public static final String HEARING_DETAIL_COLLECTION_POSTPONED =
-        "\"hearingDetailsCollection\": [{\"value\": {\"hearingDetailsStatus\": \"Heard\"}},"
-            + "{\"value\": {\"hearingDetailsStatus\": \"Postponed\"}}]";
+        "\"hearingDetailsCollection\": ["
+            + "{\"value\": {\"hearingDetailsStatus\": \"Heard\"}},"
+            + "{\"value\": {\"hearingDetailsStatus\": \"Postponed\"}}" +
+            "]";
 
     public static final String SUBMISSION_REASON_CLAIMANT_AMEND =
             HelperService.createApplications("Amend my claim", "");
@@ -478,7 +483,7 @@ class EmploymentTaskInitiationTestScot extends DmnDecisionTableBaseUnitTest {
             Arguments.of(
                 "updateHearing",
                 "Accepted",
-                HelperService.mapAdditionalData(HEARING_DETAIL_COLLECTION_HEARD),
+                HelperService.mapAdditionalData(HEARING_DETAIL_COLLECTION_HEARD_VACATED),
                 List.of(
                     HelperService.mapExpectedOutput(
                         "DraftAndSignJudgment",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-4795

### Change description ###
"Vacated" hearing dates still trigger Draft & Sign Judgement so long as one date is Heard

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
