### PR TITLE
RET-4926: ET3 Processing should only trigger once

### DIFF
--- a/src/main/resources/wa-task-initiation-employment-et_englandwales.dmn
+++ b/src/main/resources/wa-task-initiation-employment-et_englandwales.dmn
@@ -73,8 +73,8 @@ and count(additionalData.Data.respondentCollection)&gt;0)
 then
   if(additionalData.Data.respondentCollection[1].value.responseReceived)
   then
-    if(additionalData.Data.respondentCollection[1].value.responseReceivedCount=1)
-    then additionalData.Data.respondentCollection[1].value.responseReceived
+    if(additionalData.Data.respondentCollection[1].value.responseReceivedCount="1")
+    then true
     else false
   else false
 else false</text>

--- a/src/main/resources/wa-task-initiation-employment-et_englandwales.dmn
+++ b/src/main/resources/wa-task-initiation-employment-et_englandwales.dmn
@@ -70,10 +70,14 @@ else false</text>
 and additionalData.Data!=null
 and additionalData.Data.respondentCollection!=null
 and count(additionalData.Data.respondentCollection)&gt;0)
-then if(additionalData.Data.respondentCollection[1].value.responseReceived!=null)
-then additionalData.Data.respondentCollection[1].value.responseReceived
-else null
-else null</text>
+then
+  if(additionalData.Data.respondentCollection[1].value.responseReceived)
+  then
+    if(additionalData.Data.respondentCollection[1].value.responseReceivedCount=1)
+    then additionalData.Data.respondentCollection[1].value.responseReceived
+    else false
+  else false
+else false</text>
         </inputExpression>
       </input>
       <input id="InputClause_02rzajk" label="Is There An Et3 Response">

--- a/src/main/resources/wa-task-initiation-employment-et_scotland.dmn
+++ b/src/main/resources/wa-task-initiation-employment-et_scotland.dmn
@@ -73,8 +73,8 @@ and count(additionalData.Data.respondentCollection)&gt;0)
 then
   if(additionalData.Data.respondentCollection[1].value.responseReceived)
   then
-    if(additionalData.Data.respondentCollection[1].value.responseReceivedCount=1)
-    then additionalData.Data.respondentCollection[1].value.responseReceived
+    if(additionalData.Data.respondentCollection[1].value.responseReceivedCount="1")
+    then true
     else false
   else false
 else false</text>

--- a/src/main/resources/wa-task-initiation-employment-et_scotland.dmn
+++ b/src/main/resources/wa-task-initiation-employment-et_scotland.dmn
@@ -70,10 +70,14 @@ else false</text>
 and additionalData.Data!=null
 and additionalData.Data.respondentCollection!=null
 and count(additionalData.Data.respondentCollection)&gt;0)
-then if(additionalData.Data.respondentCollection[1].value.responseReceived!=null)
-then additionalData.Data.respondentCollection[1].value.responseReceived
-else null
-else null</text>
+then
+  if(additionalData.Data.respondentCollection[1].value.responseReceived)
+  then
+    if(additionalData.Data.respondentCollection[1].value.responseReceivedCount=1)
+    then additionalData.Data.respondentCollection[1].value.responseReceived
+    else false
+  else false
+else false</text>
         </inputExpression>
       </input>
       <input id="InputClause_18qp9rh" label="Is There An Et3 Response">

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestEW.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestEW.java
@@ -47,10 +47,12 @@ class EmploymentTaskInitiationTestEW extends DmnDecisionTableBaseUnitTest {
     public static final String IS_JUDGEMENT_FALSE =
         "\"draftAndSignJudgement\":{\"isJudgement\":false}";
 
-    public static final String ET3_FORM_RECEIVED =
-        "\"respondentCollection\":[{\"value\":{\"responseReceived\":true}}]";
     public static final String ET3_FORM_NOT_RECEIVED =
         "\"respondentCollection\":[{\"value\":{\"responseReceived\":false}}]";
+    public static final String ET3_FORM_RECEIVED_ONCE =
+        "\"respondentCollection\":[{\"value\":{\"responseReceived\":true,\"responseReceivedCount\":1}}]";
+    public static final String ET3_FORM_RECEIVED_MORE =
+        "\"respondentCollection\":[{\"value\":{\"responseReceived\":true,\"responseReceivedCount\":2}}]";
 
     public static final String IS_ET3_RESPONSE_TRUE =
         "\"respondentCollection\":[{\"value\":{\"et3Vetting\":{\"et3IsThereAnEt3Response\":true}}}]";
@@ -349,7 +351,13 @@ class EmploymentTaskInitiationTestEW extends DmnDecisionTableBaseUnitTest {
             Arguments.of(
                 "amendRespondentDetails",
                 null,
-                HelperService.mapAdditionalData(ET3_FORM_RECEIVED),
+                HelperService.mapAdditionalData(ET3_FORM_NOT_RECEIVED),
+                List.of()
+            ),
+            Arguments.of(
+                "amendRespondentDetails",
+                null,
+                HelperService.mapAdditionalData(ET3_FORM_RECEIVED_ONCE),
                 List.of(
                     HelperService.mapExpectedOutput(
                         "ET3Processing",
@@ -361,7 +369,7 @@ class EmploymentTaskInitiationTestEW extends DmnDecisionTableBaseUnitTest {
             Arguments.of(
                 "amendRespondentDetails",
                 null,
-                HelperService.mapAdditionalData(ET3_FORM_NOT_RECEIVED),
+                HelperService.mapAdditionalData(ET3_FORM_RECEIVED_MORE),
                 List.of()
             ),
             Arguments.of(

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestEW.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestEW.java
@@ -48,11 +48,11 @@ class EmploymentTaskInitiationTestEW extends DmnDecisionTableBaseUnitTest {
         "\"draftAndSignJudgement\":{\"isJudgement\":false}";
 
     public static final String ET3_FORM_NOT_RECEIVED =
-        "\"respondentCollection\":[{\"value\":{\"responseReceived\":false}}]";
+        "\"respondentCollection\":[{\"value\":{\"responseReceived\":false,\"responseReceivedCount\":null}}]";
     public static final String ET3_FORM_RECEIVED_ONCE =
-        "\"respondentCollection\":[{\"value\":{\"responseReceived\":true,\"responseReceivedCount\":1}}]";
+        "\"respondentCollection\":[{\"value\":{\"responseReceived\":true,\"responseReceivedCount\":\"1\"}}]";
     public static final String ET3_FORM_RECEIVED_MORE =
-        "\"respondentCollection\":[{\"value\":{\"responseReceived\":true,\"responseReceivedCount\":2}}]";
+        "\"respondentCollection\":[{\"value\":{\"responseReceived\":true,\"responseReceivedCount\":\"2\"}}]";
 
     public static final String IS_ET3_RESPONSE_TRUE =
         "\"respondentCollection\":[{\"value\":{\"et3Vetting\":{\"et3IsThereAnEt3Response\":true}}}]";

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestScot.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestScot.java
@@ -48,11 +48,11 @@ class EmploymentTaskInitiationTestScot extends DmnDecisionTableBaseUnitTest {
         "\"draftAndSignJudgement\":{\"isJudgement\":false}";
 
     public static final String ET3_FORM_NOT_RECEIVED =
-        "\"respondentCollection\":[{\"value\":{\"responseReceived\":false}}]";
+        "\"respondentCollection\":[{\"value\":{\"responseReceived\":false,\"responseReceivedCount\":null}}]";
     public static final String ET3_FORM_RECEIVED_ONCE =
-        "\"respondentCollection\":[{\"value\":{\"responseReceived\":true,\"responseReceivedCount\":1}}]";
+        "\"respondentCollection\":[{\"value\":{\"responseReceived\":true,\"responseReceivedCount\":\"1\"}}]";
     public static final String ET3_FORM_RECEIVED_MORE =
-        "\"respondentCollection\":[{\"value\":{\"responseReceived\":true,\"responseReceivedCount\":2}}]";
+        "\"respondentCollection\":[{\"value\":{\"responseReceived\":true,\"responseReceivedCount\":\"2\"}}]";
 
     public static final String IS_ET3_RESPONSE_TRUE =
         "\"respondentCollection\":[{\"value\":{\"et3Vetting\":{\"et3IsThereAnEt3Response\":true}}}]";

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestScot.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestScot.java
@@ -47,10 +47,12 @@ class EmploymentTaskInitiationTestScot extends DmnDecisionTableBaseUnitTest {
     public static final String IS_JUDGEMENT_FALSE =
         "\"draftAndSignJudgement\":{\"isJudgement\":false}";
 
-    public static final String ET3_FORM_RECEIVED =
-        "\"respondentCollection\":[{\"value\":{\"responseReceived\":true}}]";
     public static final String ET3_FORM_NOT_RECEIVED =
         "\"respondentCollection\":[{\"value\":{\"responseReceived\":false}}]";
+    public static final String ET3_FORM_RECEIVED_ONCE =
+        "\"respondentCollection\":[{\"value\":{\"responseReceived\":true,\"responseReceivedCount\":1}}]";
+    public static final String ET3_FORM_RECEIVED_MORE =
+        "\"respondentCollection\":[{\"value\":{\"responseReceived\":true,\"responseReceivedCount\":2}}]";
 
     public static final String IS_ET3_RESPONSE_TRUE =
         "\"respondentCollection\":[{\"value\":{\"et3Vetting\":{\"et3IsThereAnEt3Response\":true}}}]";
@@ -353,7 +355,13 @@ class EmploymentTaskInitiationTestScot extends DmnDecisionTableBaseUnitTest {
             Arguments.of(
                 "amendRespondentDetails",
                 null,
-                HelperService.mapAdditionalData(ET3_FORM_RECEIVED),
+                HelperService.mapAdditionalData(ET3_FORM_NOT_RECEIVED),
+                List.of()
+            ),
+            Arguments.of(
+                "amendRespondentDetails",
+                null,
+                HelperService.mapAdditionalData(ET3_FORM_RECEIVED_ONCE),
                 List.of(
                     HelperService.mapExpectedOutput(
                         "ET3Processing",
@@ -364,8 +372,8 @@ class EmploymentTaskInitiationTestScot extends DmnDecisionTableBaseUnitTest {
             ),
             Arguments.of(
                 "amendRespondentDetails",
-                "Accepted",
-                HelperService.mapAdditionalData(ET3_FORM_NOT_RECEIVED),
+                null,
+                HelperService.mapAdditionalData(ET3_FORM_RECEIVED_MORE),
                 List.of()
             ),
             Arguments.of(


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-4926

### Change description ###
ET3 Processing should only trigger once if multiple amendRespondentDetails have been executed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
