### PR TITLE
Ret 5733

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ tasks.withType(Test) {
 }
 
 test {
-  failFast = true
+  failFast = false
 }
 
 task functional(type: Test) {

--- a/src/main/resources/wa-task-configuration-employment-et_englandwales.dmn
+++ b/src/main/resources/wa-task-configuration-employment-et_englandwales.dmn
@@ -31,11 +31,9 @@ else null</text>
           <text>"caseName"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1eo7s5z">
-          <text>if (caseData.respondentCollection != null and count(caseData.respondentCollection) &gt; 0 and caseData.respondentCollection[1].value.respondent_name != null)
-then (if caseData.claimant_TypeOfClaimant = "Company" then if (caseData.claimant_Company != null) then caseData.claimant_Company else "Unknown"
-else (if (caseData.claimantIndType != null and caseData.claimantIndType.claimant_first_names != null and caseData.claimantIndType.claimant_last_name != null) then caseData.claimantIndType.claimant_first_names + " " + caseData.claimantIndType.claimant_last_name else "Unknown"))
-+ " v " + caseData.respondentCollection[1].value.respondent_name
-else if caseData.claimant_TypeOfClaimant = "Company" then caseData.claimant_Company else if (caseData.claimantIndType != null and caseData.claimantIndType.claimant_first_names != null and caseData.claimantIndType.claimant_last_name != null) then caseData.claimantIndType.claimant_first_names + " " + caseData.claimantIndType.claimant_last_name else "Unknown"</text>
+          <text>(if (caseData.claimant != null) then caseData.claimant else "Unknown")
++ " v " +
+(if (caseData.respondent != null) then caseData.respondent else "Unknown")</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_15e9efr">
           <text>true</text>

--- a/src/main/resources/wa-task-configuration-employment-et_englandwales.dmn
+++ b/src/main/resources/wa-task-configuration-employment-et_englandwales.dmn
@@ -559,7 +559,7 @@ You can also [Reply to the Referral](/cases/case-details/${[CASE_REFERENCE]}/tri
           <text>"description"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0trcq8d">
-          <text>"**Review the Application**. You can also [Record a decision](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdmin/tseAdmin1),
+          <text>"**Review the Application**. You can also [Record a decision](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdmin/tseAdmin1), 
 [Respond to an application](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdmReply/tseAdmReply1) or [Close application](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdminCloseAnApplication/tseAdminCloseAnApplication1)"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0celo90">

--- a/src/main/resources/wa-task-configuration-employment-et_englandwales.dmn
+++ b/src/main/resources/wa-task-configuration-employment-et_englandwales.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition-et_englandwales" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.30.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition-et_englandwales" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.32.0">
   <decision id="wa-task-configuration-employment-et_englandwales" name="ET Task configuration DMN" camunda:historyTimeToLive="P30D">
     <decisionTable id="DecisionTable_14cx079" hitPolicy="COLLECT">
       <input id="InputClause_1gxyo7f" label="CCD Case Data" camunda:inputVariable="caseData">
@@ -17,7 +17,7 @@ else null</text>
         </inputExpression>
       </input>
       <output id="Output_1" label="Name" name="name" typeRef="string" biodi:width="258" />
-      <output id="OutputClause_021y3bb" label="Value" name="value" typeRef="string" biodi:width="1014" />
+      <output id="OutputClause_021y3bb" label="Value" name="value" typeRef="string" biodi:width="678" />
       <output id="OutputClause_0tefly7" label="Can Reconfigure?" name="canReconfigure" typeRef="boolean" />
       <rule id="DecisionRule_19opwhc">
         <description>1v1 scenario - Concatenates Claimant's forename name with that of respondent to create the case name displayed on task lists</description>
@@ -31,10 +31,11 @@ else null</text>
           <text>"caseName"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1eo7s5z">
-          <text>if (caseData.respondentCollection != null and count(caseData.respondentCollection) &gt; 0)
-then caseData.claimantIndType.claimant_first_names + " " + caseData.claimantIndType.claimant_last_name
-+ " v " + (caseData.respondentCollection[1]).value.respondent_name
-else caseData.claimantIndType.claimant_first_names + " " + caseData.claimantIndType.claimant_last_name</text>
+          <text>if (caseData.respondentCollection != null and count(caseData.respondentCollection) &gt; 0 and caseData.respondentCollection[1].value.respondent_name != null)
+then (if caseData.claimant_TypeOfClaimant = "Company" then if (caseData.claimant_Company != null) then caseData.claimant_Company else "Unknown"
+else (if (caseData.claimantIndType != null and caseData.claimantIndType.claimant_first_names != null and caseData.claimantIndType.claimant_last_name != null) then caseData.claimantIndType.claimant_first_names + " " + caseData.claimantIndType.claimant_last_name else "Unknown"))
++ " v " + caseData.respondentCollection[1].value.respondent_name
+else if caseData.claimant_TypeOfClaimant = "Company" then caseData.claimant_Company else if (caseData.claimantIndType != null and caseData.claimantIndType.claimant_first_names != null and caseData.claimantIndType.claimant_last_name != null) then caseData.claimantIndType.claimant_first_names + " " + caseData.claimantIndType.claimant_last_name else "Unknown"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_15e9efr">
           <text>true</text>
@@ -560,7 +561,7 @@ You can also [Reply to the Referral](/cases/case-details/${[CASE_REFERENCE]}/tri
           <text>"description"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0trcq8d">
-          <text>"**Review the Application**. You can also [Record a decision](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdmin/tseAdmin1),\ 
+          <text>"**Review the Application**. You can also [Record a decision](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdmin/tseAdmin1),\
 [Respond to an application](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdmReply/tseAdmReply1) or [Close application](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdminCloseAnApplication/tseAdminCloseAnApplication1)"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0celo90">

--- a/src/main/resources/wa-task-configuration-employment-et_scotland.dmn
+++ b/src/main/resources/wa-task-configuration-employment-et_scotland.dmn
@@ -31,11 +31,9 @@ else null</text>
           <text>"caseName"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1eo7s5z">
-          <text>if (caseData.respondentCollection != null and count(caseData.respondentCollection) &gt; 0 and caseData.respondentCollection[1].value.respondent_name != null)
-then (if caseData.claimant_TypeOfClaimant = "Company" then if (caseData.claimant_Company != null) then caseData.claimant_Company else "Unknown"
-else (if (caseData.claimantIndType != null and caseData.claimantIndType.claimant_first_names != null and caseData.claimantIndType.claimant_last_name != null) then caseData.claimantIndType.claimant_first_names + " " + caseData.claimantIndType.claimant_last_name else "Unknown"))
-+ " v " + caseData.respondentCollection[1].value.respondent_name
-else if caseData.claimant_TypeOfClaimant = "Company" then caseData.claimant_Company else if (caseData.claimantIndType != null and caseData.claimantIndType.claimant_first_names != null and caseData.claimantIndType.claimant_last_name != null) then caseData.claimantIndType.claimant_first_names + " " + caseData.claimantIndType.claimant_last_name else "Unknown"</text>
+          <text>(if (caseData.claimant != null) then caseData.claimant else "Unknown")
++ " v " +
+(if (caseData.respondent != null) then caseData.respondent else "Unknown")</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_15e9efr">
           <text>true</text>
@@ -561,7 +559,7 @@ You can also [Reply to the Referral](/cases/case-details/${[CASE_REFERENCE]}/tri
           <text>"description"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0k9sgy7">
-          <text>"**Review the Application**. You can also [Record a decision](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdmin/tseAdmin1),  
+          <text>"**Review the Application**. You can also [Record a decision](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdmin/tseAdmin1),
 [Respond to an application](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdmReply/tseAdmReply1) or [Close application](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdminCloseAnApplication/tseAdminCloseAnApplication1)"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1hnp98x">

--- a/src/main/resources/wa-task-configuration-employment-et_scotland.dmn
+++ b/src/main/resources/wa-task-configuration-employment-et_scotland.dmn
@@ -559,7 +559,7 @@ You can also [Reply to the Referral](/cases/case-details/${[CASE_REFERENCE]}/tri
           <text>"description"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0k9sgy7">
-          <text>"**Review the Application**. You can also [Record a decision](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdmin/tseAdmin1),
+          <text>"**Review the Application**. You can also [Record a decision](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdmin/tseAdmin1), 
 [Respond to an application](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdmReply/tseAdmReply1) or [Close application](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdminCloseAnApplication/tseAdminCloseAnApplication1)"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1hnp98x">

--- a/src/main/resources/wa-task-configuration-employment-et_scotland.dmn
+++ b/src/main/resources/wa-task-configuration-employment-et_scotland.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition-et_scotland" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.30.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="wa-configuration-definition-et_scotland" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.32.0">
   <decision id="wa-task-configuration-employment-et_scotland" name="ET Task configuration DMN" camunda:historyTimeToLive="P30D">
     <decisionTable id="DecisionTable_14cx079" hitPolicy="COLLECT">
       <input id="InputClause_1gxyo7f" label="CCD Case Data" camunda:inputVariable="caseData">
@@ -31,10 +31,11 @@ else null</text>
           <text>"caseName"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1eo7s5z">
-          <text>if (caseData.respondentCollection != null and count(caseData.respondentCollection) &gt; 0)
-then caseData.claimantIndType.claimant_first_names + " " + caseData.claimantIndType.claimant_last_name
-+ " v " + (caseData.respondentCollection[1]).value.respondent_name
-else caseData.claimantIndType.claimant_first_names + " " + caseData.claimantIndType.claimant_last_name</text>
+          <text>if (caseData.respondentCollection != null and count(caseData.respondentCollection) &gt; 0 and caseData.respondentCollection[1].value.respondent_name != null)
+then (if caseData.claimant_TypeOfClaimant = "Company" then if (caseData.claimant_Company != null) then caseData.claimant_Company else "Unknown"
+else (if (caseData.claimantIndType != null and caseData.claimantIndType.claimant_first_names != null and caseData.claimantIndType.claimant_last_name != null) then caseData.claimantIndType.claimant_first_names + " " + caseData.claimantIndType.claimant_last_name else "Unknown"))
++ " v " + caseData.respondentCollection[1].value.respondent_name
+else if caseData.claimant_TypeOfClaimant = "Company" then caseData.claimant_Company else if (caseData.claimantIndType != null and caseData.claimantIndType.claimant_first_names != null and caseData.claimantIndType.claimant_last_name != null) then caseData.claimantIndType.claimant_first_names + " " + caseData.claimantIndType.claimant_last_name else "Unknown"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_15e9efr">
           <text>true</text>

--- a/src/main/resources/wa-task-configuration-employment-et_scotland.dmn
+++ b/src/main/resources/wa-task-configuration-employment-et_scotland.dmn
@@ -559,7 +559,7 @@ You can also [Reply to the Referral](/cases/case-details/${[CASE_REFERENCE]}/tri
           <text>"description"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_0k9sgy7">
-          <text>"**Review the Application**. You can also [Record a decision](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdmin/tseAdmin1), 
+          <text>"**Review the Application**. You can also [Record a decision](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdmin/tseAdmin1),  
 [Respond to an application](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdmReply/tseAdmReply1) or [Close application](/cases/case-details/${[CASE_REFERENCE]}/trigger/tseAdminCloseAnApplication/tseAdminCloseAnApplication1)"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1hnp98x">

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskConfigurationTestScot.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskConfigurationTestScot.java
@@ -36,32 +36,59 @@ class EmploymentTaskConfigurationTestScot extends DmnDecisionTableBaseUnitTest {
     private static final String DEFAULT_CALENDAR = "https://www.gov.uk/bank-holidays/scotland.json";
 
     @BeforeAll
-    public static void initialization() {
+    static void initialization() {
         CURRENT_DMN_DECISION_TABLE = WA_TASK_CONFIGURATION_ET_SCOTLAND;
     }
 
     private static Map<String, Object> getDefaultCaseData() {
-        Map<String, Object> claimant = new HashMap<>();
-        claimant.put("claimant_first_names", "George");
-        claimant.put("claimant_last_name", "Jetson");
-
         Map<String, Object> caseData = new HashMap<>();
-        caseData.put("claimantIndType", claimant);
-
+        caseData.put("claimant", "George Jetson");
         return caseData;
     }
 
-    @ParameterizedTest
-    @MethodSource("respondentCollection_ScenarioProvider")
-    void testCaseNameWithRespondentCollection(String rawRespondentCollection, String expectedCaseName) {
+    @Test
+    void nullClaimantAndRespondentName() {
         // Given
         Map<String, Object> caseData = getDefaultCaseData();
+        caseData.put("claimant", null);
+        caseData.put("respondent", null);
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("caseData", caseData);
+        inputVariables.putValue("taskAttributes", Map.of("taskType", "Et1Vetting"));
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
 
-        if (!rawRespondentCollection.isBlank()) {
-            Map<String, Object> parsedRespondentCollection = HelperService.mapData(rawRespondentCollection);
-            caseData.put("respondentCollection", parsedRespondentCollection.get("respondentCollection"));
-        }
+        List<Map<String, Object>> resultList =
+            dmnDecisionTableResult
+                .getResultList()
+                .stream()
+                .filter(r -> r.containsValue("caseName"))
+                .toList();
 
+        // Then
+        assertEquals("Unknown v Unknown", resultList.get(0).get("value"));
+    }
+
+    public static Stream<Arguments> claimantName_ScenarioProvider() {
+        return Stream.of(
+            // null claimant name
+            Arguments.of(
+                null,
+                "Unknown v Cosmo Spacely"
+            ),
+            // valid respondent name
+            Arguments.of("George Jetson",
+                         "George Jetson v Cosmo Spacely"
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("claimantName_ScenarioProvider")
+    void testCaseNameWithClaimantName(String claimantName, String expectedCaseName) {
+        // Given
+        Map<String, Object> caseData = getDefaultCaseData();
+        caseData.put("claimant", claimantName);
+        caseData.put("respondent", "Cosmo Spacely");
         VariableMap inputVariables = new VariableMapImpl();
         inputVariables.putValue("caseData", caseData);
         inputVariables.putValue("taskAttributes", Map.of("taskType", "Et1Vetting"));
@@ -73,39 +100,47 @@ class EmploymentTaskConfigurationTestScot extends DmnDecisionTableBaseUnitTest {
             dmnDecisionTableResult
                 .getResultList()
                 .stream()
-                .filter((r) -> r.containsValue("caseName"))
+                .filter(r -> r.containsValue("caseName"))
                 .toList();
 
         // Then
         assertEquals(expectedCaseName, resultList.get(0).get("value"));
     }
 
-    public static Stream<Arguments> respondentCollection_ScenarioProvider() {
+    @ParameterizedTest
+    @MethodSource("respondentName_ScenarioProvider")
+    void testCaseNameWithRespondentName(String respondentName, String expectedCaseName) {
+        // Given
+        Map<String, Object> caseData = getDefaultCaseData();
+        caseData.put("respondent", respondentName);
+        VariableMap inputVariables = new VariableMapImpl();
+        inputVariables.putValue("caseData", caseData);
+        inputVariables.putValue("taskAttributes", Map.of("taskType", "Et1Vetting"));
+
+        // When
+        DmnDecisionTableResult dmnDecisionTableResult = evaluateDmnTable(inputVariables);
+
+        List<Map<String, Object>> resultList =
+            dmnDecisionTableResult
+                .getResultList()
+                .stream()
+                .filter(r -> r.containsValue("caseName"))
+                .toList();
+
+        // Then
+        assertEquals(expectedCaseName, resultList.get(0).get("value"));
+    }
+
+    public static Stream<Arguments> respondentName_ScenarioProvider() {
         return Stream.of(
-            // No respondentCollection
+            // null respondentName
             Arguments.of(
-                "",
-                "George Jetson"
+                null,
+                "George Jetson v Unknown"
             ),
-            // empty respondentCollection
-            Arguments.of(
-                "{\"respondentCollection\":[]}",
-                "George Jetson"
-            ),
-            // respondentCollection with one Respondent
-            Arguments.of(
-                "{\"respondentCollection\":["
-                    + "{ \"value\":{ \"respondent_name\":\"Cosmo Spacely\" }}"
-                    + "]}",
-                "George Jetson v Cosmo Spacely"
-            ),
-            // respondentCollection with 2+
-            Arguments.of(
-                "{\"respondentCollection\":["
-                    + "{ \"value\":{ \"respondent_name\":\"Cosmo Spacely\" }},"
-                    + "{ \"value\":{ \"respondent_name\":\"Coswell Cogs\" }}"
-                    + "]}",
-                "George Jetson v Cosmo Spacely"
+            // valid respondentName
+            Arguments.of("Cosmo Spacely",
+                         "George Jetson v Cosmo Spacely"
             )
         );
     }
@@ -984,7 +1019,7 @@ class EmploymentTaskConfigurationTestScot extends DmnDecisionTableBaseUnitTest {
 
     private List<Map<String, Object>> getExpectedValues() {
         List<Map<String, Object>> rules = new ArrayList<>();
-        HelperService.getExpectedValueWithReconfigure(rules, "caseName", "George Jetson", true);
+        HelperService.getExpectedValueWithReconfigure(rules, "caseName", "George Jetson v Unknown", true);
         HelperService.getExpectedValueWithReconfigure(rules, "region", "11", true);
         HelperService.getExpectedValueWithReconfigure(rules, "location", "368308", true);
         HelperService.getExpectedValueWithReconfigure(rules, "locationName", "Edinburgh", true);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-5733

### Change description ###

- Change logic for caseName to use claimant and respondent field to work with both when party is Individual or Company/Organisation
- If claimant or respondent is null, rather than causing the task to fail generation, it will use Unknown
![Screenshot 2025-03-21 at 13 59 17](https://github.com/user-attachments/assets/e0366175-7859-49cc-a38f-ee3c69df66da)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
