### PR TITLE
due date reset bug fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ version = '0.0.1'
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(21)
   }
 }
 

--- a/src/main/resources/wa-task-configuration-employment-et_englandwales.dmn
+++ b/src/main/resources/wa-task-configuration-employment-et_englandwales.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="wa-configuration-definition-et_englandwales" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.35.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="wa-configuration-definition-et_englandwales" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.36.1">
   <decision id="wa-task-configuration-employment-et_englandwales" name="ET Task configuration DMN" camunda:historyTimeToLive="P30D">
     <informationRequirement id="InformationRequirement_0cm80l7">
       <requiredDecision href="#Decision_1lqqy4i" />
@@ -749,7 +749,7 @@ else ""</text>
           <text>5000</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1mzeeq8">
-          <text>true</text>
+          <text>false</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1ua5utw">
@@ -831,7 +831,7 @@ else 5000</text>
           <text>500</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1lezcx4">
-          <text>true</text>
+          <text>false</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0bz90wb">
@@ -896,7 +896,7 @@ else 500</text>
           <text>"nextHearingDate,dueDate,priorityDate"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_13crvik">
-          <text>true</text>
+          <text>false</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0h2yrh9">
@@ -913,7 +913,7 @@ else 500</text>
           <text>time("16:00")</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1t5kkwb">
-          <text>true</text>
+          <text>false</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_108ksv2">
@@ -930,7 +930,7 @@ else 500</text>
           <text>now()</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1cg2n4r">
-          <text>true</text>
+          <text>false</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0cb9nef">
@@ -1261,7 +1261,7 @@ else 2</text>
           <text>"dueDate"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1tt1zjs">
-          <text>true</text>
+          <text>false</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_08bmr9f">
@@ -1280,7 +1280,7 @@ else 2</text>
           <text>"dueDate, nextHearingDate"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_14f6prs">
-          <text>true</text>
+          <text>false</text>
         </outputEntry>
       </rule>
     </decisionTable>

--- a/src/main/resources/wa-task-configuration-employment-et_scotland.dmn
+++ b/src/main/resources/wa-task-configuration-employment-et_scotland.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="wa-configuration-definition-et_scotland" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.35.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="wa-configuration-definition-et_scotland" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.36.1">
   <decision id="wa-task-configuration-employment-et_scotland" name="ET Task configuration DMN" camunda:historyTimeToLive="P30D">
     <informationRequirement id="InformationRequirement_181rjsg">
       <requiredDecision href="#Decision_07yhq0k" />
@@ -750,7 +750,7 @@ else ""</text>
           <text>5000</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1mzeeq8">
-          <text>true</text>
+          <text>false</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1ua5utw">
@@ -832,7 +832,7 @@ else 5000</text>
           <text>500</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1lezcx4">
-          <text>true</text>
+          <text>false</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0bz90wb">
@@ -897,7 +897,7 @@ else 500</text>
           <text>"nextHearingDate,dueDate,priorityDate"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_13crvik">
-          <text>true</text>
+          <text>false</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_108ksv2">
@@ -914,7 +914,7 @@ else 500</text>
           <text>now()</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1cg2n4r">
-          <text>true</text>
+          <text>false</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0h2yrh9">
@@ -931,7 +931,7 @@ else 500</text>
           <text>time("16:00")</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1t5kkwb">
-          <text>true</text>
+          <text>false</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_1ph4gqo">
@@ -1262,7 +1262,7 @@ else 2</text>
           <text>"dueDate"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1tt1zjs">
-          <text>true</text>
+          <text>false</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_0bva8w0">
@@ -1281,7 +1281,7 @@ else 2</text>
           <text>"dueDate, nextHearingDate"</text>
         </outputEntry>
         <outputEntry id="LiteralExpression_1cmb6lz">
-          <text>true</text>
+          <text>false</text>
         </outputEntry>
       </rule>
     </decisionTable>

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskConfigurationTestEW.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskConfigurationTestEW.java
@@ -773,7 +773,7 @@ class EmploymentTaskConfigurationTestEW extends DmnDecisionTableBaseUnitTest {
         List<Map<String, Object>> defaultMajorPriority = List.of(Map.of(
             "name", "majorPriority",
             "value", "5000",
-            "canReconfigure", true
+            "canReconfigure", false
         ));
         List<Map<String, Object>> defaultMajorPriorityNoReconfigure = List.of(Map.of(
             "name", "majorPriority",
@@ -783,7 +783,7 @@ class EmploymentTaskConfigurationTestEW extends DmnDecisionTableBaseUnitTest {
         List<Map<String, Object>> defaultMinorPriority = List.of(Map.of(
             "name", "minorPriority",
             "value", "500",
-            "canReconfigure", true
+            "canReconfigure", false
         ));
         List<Map<String, Object>> defaultMinorPriorityNoReconfigure = List.of(Map.of(
             "name", "minorPriority",
@@ -804,12 +804,12 @@ class EmploymentTaskConfigurationTestEW extends DmnDecisionTableBaseUnitTest {
         List<Map<String, Object>> priorityDateOriginRef = List.of(Map.of(
             "name", "priorityDateOriginRef",
             "value", "dueDate",
-            "canReconfigure", true
+            "canReconfigure", false
         ));
         List<Map<String, Object>> priorityDateOriginEar = List.of(Map.of(
             "name", "priorityDateOriginEarliest",
             "value", "dueDate, nextHearingDate",
-            "canReconfigure", true
+            "canReconfigure", false
         ));
 
         return Stream.of(
@@ -949,13 +949,13 @@ class EmploymentTaskConfigurationTestEW extends DmnDecisionTableBaseUnitTest {
         assertEquals(Map.of(
             "name", "calculatedDates",
             "value", "nextHearingDate,dueDate,priorityDate",
-            "canReconfigure", true
+            "canReconfigure", false
         ), resultList.get(11));
 
         assertEquals(Map.of(
             "name", "dueDateTime",
             "value", "16:00",
-            "canReconfigure", true
+            "canReconfigure", false
         ), resultList.get(12));
 
         /*assertEquals(
@@ -1043,9 +1043,9 @@ class EmploymentTaskConfigurationTestEW extends DmnDecisionTableBaseUnitTest {
         HelperService.getExpectedValueWithReconfigure(rules, "caseManagementCategory", "Employment", false);
         HelperService.getExpectedValueWithReconfigure(rules, "nextHearingDate", "", true);
         HelperService.getExpectedValueWithReconfigure(
-            rules, "calculatedDates", "nextHearingDate,dueDate,priorityDate", true);
-        HelperService.getExpectedValueWithReconfigure(rules, "dueDateTime", "16:00", true);
-        HelperService.getExpectedValueWithReconfigure(rules, "dueDateOrigin", null, true);
+            rules, "calculatedDates", "nextHearingDate,dueDate,priorityDate", false);
+        HelperService.getExpectedValueWithReconfigure(rules, "dueDateTime", "16:00", false);
+        HelperService.getExpectedValueWithReconfigure(rules, "dueDateOrigin", null, false);
 
         HelperService.getExpectedValueWithReconfigure(
             rules, "dueDateNonWorkingCalendar", DEFAULT_CALENDAR + ", " + EXTRA_TEST_CALENDAR_ENGWALES, true);

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskConfigurationTestScot.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskConfigurationTestScot.java
@@ -775,7 +775,7 @@ class EmploymentTaskConfigurationTestScot extends DmnDecisionTableBaseUnitTest {
         List<Map<String, Object>> defaultMajorPriority = List.of(Map.of(
             "name", "majorPriority",
             "value", "5000",
-            "canReconfigure", true
+            "canReconfigure", false
         ));
         List<Map<String, Object>> defaultMajorPriorityNoReconfigure = List.of(Map.of(
             "name", "majorPriority",
@@ -785,7 +785,7 @@ class EmploymentTaskConfigurationTestScot extends DmnDecisionTableBaseUnitTest {
         List<Map<String, Object>> defaultMinorPriority = List.of(Map.of(
             "name", "minorPriority",
             "value", "500",
-            "canReconfigure", true
+            "canReconfigure", false
         ));
         List<Map<String, Object>> defaultMinorPriorityNoReconfigure = List.of(Map.of(
             "name", "minorPriority",
@@ -806,12 +806,12 @@ class EmploymentTaskConfigurationTestScot extends DmnDecisionTableBaseUnitTest {
         List<Map<String, Object>> priorityDateOriginRef = List.of(Map.of(
             "name", "priorityDateOriginRef",
             "value", "dueDate",
-            "canReconfigure", true
+            "canReconfigure", false
         ));
         List<Map<String, Object>> priorityDateOriginEar = List.of(Map.of(
             "name", "priorityDateOriginEarliest",
             "value", "dueDate, nextHearingDate",
-            "canReconfigure", true
+            "canReconfigure", false
         ));
 
         return Stream.of(
@@ -952,13 +952,13 @@ class EmploymentTaskConfigurationTestScot extends DmnDecisionTableBaseUnitTest {
         assertEquals(Map.of(
             "name", "calculatedDates",
             "value", "nextHearingDate,dueDate,priorityDate",
-            "canReconfigure", true
+            "canReconfigure", false
         ), resultList.get(11));
 
         assertEquals(Map.of(
             "name", "dueDateTime",
             "value", "16:00",
-            "canReconfigure", true
+            "canReconfigure", false
         ), resultList.get(13));
 
         assertEquals(Map.of(
@@ -1038,9 +1038,9 @@ class EmploymentTaskConfigurationTestScot extends DmnDecisionTableBaseUnitTest {
         HelperService.getExpectedValueWithReconfigure(rules, "caseManagementCategory", "Employment", false);
         HelperService.getExpectedValueWithReconfigure(rules, "nextHearingDate", "", true);
         HelperService.getExpectedValueWithReconfigure(
-            rules, "calculatedDates", "nextHearingDate,dueDate,priorityDate", true);
-        HelperService.getExpectedValueWithReconfigure(rules, "dueDateOrigin", null, true);
-        HelperService.getExpectedValueWithReconfigure(rules, "dueDateTime", "16:00", true);
+            rules, "calculatedDates", "nextHearingDate,dueDate,priorityDate", false);
+        HelperService.getExpectedValueWithReconfigure(rules, "dueDateOrigin", null, false);
+        HelperService.getExpectedValueWithReconfigure(rules, "dueDateTime", "16:00", false);
         HelperService.getExpectedValueWithReconfigure(
             rules, "dueDateNonWorkingCalendar", DEFAULT_CALENDAR + ", " + EXTRA_TEST_CALENDAR_SCOTLAND, true);
         HelperService.getExpectedValueWithReconfigure(rules, "dueDateNonWorkingDaysOfWeek", "SATURDAY,SUNDAY", true);


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-5929


### Change description ###
Configuration DMNs updated to prevent due date reset when task reconfiguration and/or new task creating events are invoked.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
