### PR TITLE
RET-6582: Add null-safe CURRENT_NOTIFICATION_NAME FEEL logic

### DIFF
--- a/src/main/resources/wa-task-initiation-employment-et_englandwales.dmn
+++ b/src/main/resources/wa-task-initiation-employment-et_englandwales.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="wa-initiation-definition-et_englandwales" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.40.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="wa-initiation-definition-et_englandwales" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.33.1">
   <decision id="wa-task-initiation-employment-et_englandwales" name="ET Task initiation DMN" camunda:historyTimeToLive="P30D">
     <informationRequirement id="InformationRequirement_04wvk1b">
       <requiredDecision href="#Decision_1exmu8q" />
@@ -4246,29 +4246,32 @@ else
   <decision id="Decision_1ovsovm" name="CURRENT_NOTIFICATION_NAME">
     <variable id="InformationItem_0bchklv" name="CURRENT_NOTIFICATION_NAME" typeRef="string" />
     <literalExpression id="LiteralExpression_09kylt3">
-      <text>if(additionalData != null
+      <text>if additionalData != null
   and additionalData.Data != null
   and additionalData.Data.sendNotificationCollection != null
-  and count(additionalData.Data.sendNotificationCollection[number(value.sendNotificationResponsesCount) &gt; 0]) &gt; 0)
-then "Review notification " + string(
-  sort(
+  and count(additionalData.Data.sendNotificationCollection[number(value.sendNotificationResponsesCount) &gt; 0]) &gt; 0
+then (for r in [sort(
     for i in 1..count(additionalData.Data.sendNotificationCollection)
     return {
       position: i,
       latestDateTime: if(additionalData.Data.sendNotificationCollection[i].value.respondCollection != null
                         and count(additionalData.Data.sendNotificationCollection[i].value.respondCollection) &gt; 0)
                       then sort(
-                        additionalData.Data.sendNotificationCollection[i].value.respondCollection,
-                        function(a, b)
-                          date and time(if(a.value.dateTime != null) then a.value.dateTime else "2023-01-01T00:00:00.000") &gt;
-                          date and time(if(b.value.dateTime != null) then b.value.dateTime else "2023-01-01T00:00:00.000")
-                      )[1].value.dateTime
+                          additionalData.Data.sendNotificationCollection[i].value.respondCollection,
+                          function(a, b)
+                            date and time(if(a.value.dateTime != null) then a.value.dateTime else "2023-01-01T00:00:00.000") &gt;
+                            date and time(if(b.value.dateTime != null) then b.value.dateTime else "2023-01-01T00:00:00.000")
+                        )[1].value.dateTime
                       else "2023-01-01T00:00:00.000"
     },
     function(x, y)
-      date and time(x.latestDateTime) &gt; date and time(y.latestDateTime)
-  )[1].position
-) + " response"
+      date and time(if(x.latestDateTime != null) then x.latestDateTime else "2023-01-01T00:00:00.000") &gt;
+      date and time(if(y.latestDateTime != null) then y.latestDateTime else "2023-01-01T00:00:00.000")
+  )[1]]
+  return if r != null and r.position != null
+         then "Review notification " + string(r.position) + " response"
+         else "Review notification response"
+)[1]
 else ""</text>
     </literalExpression>
   </decision>

--- a/src/main/resources/wa-task-initiation-employment-et_scotland.dmn
+++ b/src/main/resources/wa-task-initiation-employment-et_scotland.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="wa-initiation-definition-et_scotland" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.40.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="wa-initiation-definition-et_scotland" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.33.1">
   <decision id="wa-task-initiation-employment-et_scotland" name="ET Task initiation DMN" camunda:historyTimeToLive="P30D">
     <informationRequirement id="InformationRequirement_15zhznm">
       <requiredDecision href="#Decision_0mhlyhp" />
@@ -4431,26 +4431,32 @@ else
   <decision id="Decision_1ju3q23" name="CURRENT_NOTIFICATION_NAME">
     <variable id="InformationItem_09yl1ar" name="CURRENT_NOTIFICATION_NAME" typeRef="string" />
     <literalExpression id="LiteralExpression_0zr0vet">
-      <text>if(additionalData != null
+      <text>if additionalData != null
   and additionalData.Data != null
-  and additionalData.Data.sendNotificationCollection != null                                                                                                                  and count(additionalData.Data.sendNotificationCollection[number(value.sendNotificationResponsesCount) &gt; 0]) &gt; 0)
-then "Review notification " + sort(
-  additionalData.Data.sendNotificationCollection[number(value.sendNotificationResponsesCount) &gt; 0],                                                                            function(x, y)
-    date and time(                                        
-      sort(x.value.respondCollection,                    
-          function(a, b)                                    
-            date and time(if(a.value.dateTime != null) then a.value.dateTime else "2023-01-01T00:00:00.000") &gt;
-            date and time(if(b.value.dateTime != null) then b.value.dateTime else "2023-01-01T00:00:00.000")            
-        )[1].value.dateTime           
-      ) &gt;                     
-      date and time(
-        sort(y.value.respondCollection,                     
-          function(a, b)
-            date and time(if(a.value.dateTime != null) then a.value.dateTime else "2023-01-01T00:00:00.000") &gt;
-            date and time(if(b.value.dateTime != null) then b.value.dateTime else "2023-01-01T00:00:00.000")              
-        )[1].value.dateTime
-      )                                                                                                                                                                    
-  )[1].value.number + " response"
+  and additionalData.Data.sendNotificationCollection != null
+  and count(additionalData.Data.sendNotificationCollection[number(value.sendNotificationResponsesCount) &gt; 0]) &gt; 0
+then (for r in [sort(
+    for i in 1..count(additionalData.Data.sendNotificationCollection)
+    return {
+      position: i,
+      latestDateTime: if(additionalData.Data.sendNotificationCollection[i].value.respondCollection != null
+                        and count(additionalData.Data.sendNotificationCollection[i].value.respondCollection) &gt; 0)
+                      then sort(
+                          additionalData.Data.sendNotificationCollection[i].value.respondCollection,
+                          function(a, b)
+                            date and time(if(a.value.dateTime != null) then a.value.dateTime else "2023-01-01T00:00:00.000") &gt;
+                            date and time(if(b.value.dateTime != null) then b.value.dateTime else "2023-01-01T00:00:00.000")
+                        )[1].value.dateTime
+                      else "2023-01-01T00:00:00.000"
+    },
+    function(x, y)
+      date and time(if(x.latestDateTime != null) then x.latestDateTime else "2023-01-01T00:00:00.000") &gt;
+      date and time(if(y.latestDateTime != null) then y.latestDateTime else "2023-01-01T00:00:00.000")
+  )[1]]
+  return if r != null and r.position != null
+         then "Review notification " + string(r.position) + " response"
+         else "Review notification response"
+)[1]
 else ""</text>
     </literalExpression>
   </decision>

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestEW.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestEW.java
@@ -40,6 +40,8 @@ import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.MULTIP
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.MULTIPLE_RESPONDENTS_NO_VALID_ECC_REPLY;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.MULTIPLE_RESPONDENTS_WITH_VALID_ECC_REPLY;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.NOTIFICATIONS_LIST;
+import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.NOTIFICATIONS_NON_ECC_WITH_DATETIME;
+import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.NOTIFICATIONS_WITH_NULL_DATETIME_RESPONSE;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.REFERRAL_ADMIN;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.REFERRAL_ADMIN_HEARING;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.REFERRAL_ADMIN_JUDGMENT;
@@ -896,6 +898,46 @@ class EmploymentTaskInitiationTestEW extends DmnDecisionTableBaseUnitTest {
                     HelperService.mapExpectedOutput(
                         "SubmitClaimantPseResponse",
                         "",
+                        "Application"
+                    )
+                )
+            ),
+            // CURRENT_NOTIFICATION_NAME: notification at position 2 has a Respondent response
+            // with a valid dateTime — expects the position embedded in the task name.
+            Arguments.of(
+                "UPDATE_NOTIFICATION_RESPONSE",
+                null,
+                HelperService.mapAdditionalData(NOTIFICATIONS_NON_ECC_WITH_DATETIME),
+                List.of(
+                    HelperService.mapExpectedOutput(
+                        "SubmitClaimantPseResponse",
+                        "Review notification 2 response",
+                        "Application"
+                    )
+                )
+            ),
+            Arguments.of(
+                "SUBMIT_STORED_PSE_RESPONSE",
+                null,
+                HelperService.mapAdditionalData(NOTIFICATIONS_NON_ECC_WITH_DATETIME),
+                List.of(
+                    HelperService.mapExpectedOutput(
+                        "SubmitClaimantPseResponse",
+                        "Review notification 2 response",
+                        "Application"
+                    )
+                )
+            ),
+            // CURRENT_NOTIFICATION_NAME: response exists but dateTime is null —
+            // fallback sort still resolves the position correctly.
+            Arguments.of(
+                "SUBMIT_STORED_PSE_RESPONSE",
+                null,
+                HelperService.mapAdditionalData(NOTIFICATIONS_WITH_NULL_DATETIME_RESPONSE),
+                List.of(
+                    HelperService.mapExpectedOutput(
+                        "SubmitClaimantPseResponse",
+                        "Review notification 1 response",
                         "Application"
                     )
                 )

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestScot.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestScot.java
@@ -38,6 +38,8 @@ import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.MULTIP
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.MULTIPLE_RESPONDENTS_NO_VALID_ECC_REPLY;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.MULTIPLE_RESPONDENTS_WITH_VALID_ECC_REPLY;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.NOTIFICATIONS_LIST;
+import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.NOTIFICATIONS_NON_ECC_WITH_DATETIME;
+import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.NOTIFICATIONS_WITH_NULL_DATETIME_RESPONSE;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.REFERRAL_ADMIN;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.REFERRAL_ADMIN_HEARING;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.REFERRAL_ADMIN_JUDGMENT;
@@ -850,6 +852,46 @@ class EmploymentTaskInitiationTestScot extends DmnDecisionTableBaseUnitTest {
                     HelperService.mapExpectedOutput(
                         "SubmitClaimantPseResponse",
                         "",
+                        "Application"
+                    )
+                )
+            ),
+            // CURRENT_NOTIFICATION_NAME: notification at position 2 has a Respondent response
+            // with a valid dateTime — expects the position embedded in the task name.
+            Arguments.of(
+                "UPDATE_NOTIFICATION_RESPONSE",
+                null,
+                HelperService.mapAdditionalData(NOTIFICATIONS_NON_ECC_WITH_DATETIME),
+                List.of(
+                    HelperService.mapExpectedOutput(
+                        "SubmitClaimantPseResponse",
+                        "Review notification 2 response",
+                        "Application"
+                    )
+                )
+            ),
+            Arguments.of(
+                "SUBMIT_STORED_PSE_RESPONSE",
+                null,
+                HelperService.mapAdditionalData(NOTIFICATIONS_NON_ECC_WITH_DATETIME),
+                List.of(
+                    HelperService.mapExpectedOutput(
+                        "SubmitClaimantPseResponse",
+                        "Review notification 2 response",
+                        "Application"
+                    )
+                )
+            ),
+            // CURRENT_NOTIFICATION_NAME: response exists but dateTime is null —
+            // fallback sort still resolves the position correctly.
+            Arguments.of(
+                "SUBMIT_STORED_PSE_RESPONSE",
+                null,
+                HelperService.mapAdditionalData(NOTIFICATIONS_WITH_NULL_DATETIME_RESPONSE),
+                List.of(
+                    HelperService.mapExpectedOutput(
+                        "SubmitClaimantPseResponse",
+                        "Review notification 1 response",
                         "Application"
                     )
                 )

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/utility/InitiationUtility.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/utility/InitiationUtility.java
@@ -198,6 +198,36 @@ public final class InitiationUtility {
     public static final String CLAIMANT_WITHDRAW_ALL_OR_PART_OF_CASE =
         HelperService.createApplications("Withdraw all/part of claim", "Claimant");
 
+    // Two notifications: position 1 has no response, position 2 has a Respondent non-ECC response
+    // with a camelCase "dateTime" field so the DMN sort can use it properly.
+    public static final String NOTIFICATIONS_NON_ECC_WITH_DATETIME =
+        HelperService.createNotifications(
+            Arrays.asList(
+                createNotification("1", "0", ""),
+                createNotification(
+                    "2",
+                    "1",
+                    ",\"respondCollection\": [{\"value\": {\"from\": \"Respondent\","
+                        + "\"dateTime\": \"2025-06-01T10:00:00.000\",\"isECC\": \"No\"}}]"
+                )
+            )
+        );
+
+    // One notification at position 1 with a response whose dateTime is null.
+    // Verifies the null-datetime fallback path in CURRENT_NOTIFICATION_NAME still
+    // returns a valid position ("Review notification 1 response").
+    public static final String NOTIFICATIONS_WITH_NULL_DATETIME_RESPONSE =
+        HelperService.createNotifications(
+            List.of(
+                createNotification(
+                    "1",
+                    "1",
+                    ",\"respondCollection\": [{\"value\": {\"from\": \"Respondent\","
+                        + "\"dateTime\": null,\"isECC\": \"No\"}}]"
+                )
+            )
+        );
+
     public static final String NOTIFICATION_1 =
         createNotification("1", "0", "");
     public static final String NOTIFICATION_2 =


### PR DESCRIPTION
## Description

Jira: https://tools.hmcts.net/jira/browse/RET-6582

Refactors the `CURRENT_NOTIFICATION_NAME` sub-decision in both the England & Wales and Scotland task initiation DMN files to safely handle null `dateTime` values in notification `respondCollection` entries.

### Changes

**DMN (both EW and Scotland)**
- Replaced direct `string(sort(...)[1].position)` concatenation with the `for r in [sort(...)[1]] return ...` pattern to avoid evaluating the sort expression twice while guarding against a null position
- Added null guard on the outer sort comparator's `latestDateTime` field
- Falls back to `"Review notification response"` (no number) if the sort result or position cannot be resolved defensively

**Tests**
- Added `NOTIFICATIONS_NON_ECC_WITH_DATETIME` and `NOTIFICATIONS_WITH_NULL_DATETIME_RESPONSE` constants to `InitiationUtility`
- Added 3 new parameterised scenarios to `EmploymentTaskInitiationTestEW` and `EmploymentTaskInitiationTestScot`:
  - `UPDATE_NOTIFICATION_RESPONSE` with non-ECC notification + valid `dateTime` → `"Review notification 2 response"`
  - `SUBMIT_STORED_PSE_RESPONSE` with valid `dateTime` → `"Review notification 2 response"`
  - `SUBMIT_STORED_PSE_RESPONSE` with null `dateTime` → `"Review notification 1 response"` (fallback sort resolves position correctly)