### PR TITLE
RET-5407: Update et3Vetting IC task logic to check all respondents

### DIFF
--- a/src/main/resources/wa-task-initiation-employment-et_englandwales.dmn
+++ b/src/main/resources/wa-task-initiation-employment-et_englandwales.dmn
@@ -97,10 +97,9 @@ else false</text>
           <text>if(additionalData!=null
 and additionalData.Data!=null
 and additionalData.Data.respondentCollection!=null
-and count(additionalData.Data.respondentCollection) &gt; 0
-and additionalData.Data.respondentCollection[1].value.et3Vetting!=null)
-then additionalData.Data.respondentCollection[1].value.et3Vetting.et3IsThereAnEt3Response
-else null</text>
+and count(additionalData.Data.respondentCollection) &gt; 0)
+then some item in additionalData.Data.respondentCollection satisfies (item.value.et3Vetting != null and item.value.et3Vetting.et3IsThereAnEt3Response = true)
+else false</text>
         </inputExpression>
       </input>
       <input id="InputClause_0la0ez2" label="Is ECC" biodi:width="192">
@@ -108,10 +107,9 @@ else null</text>
           <text>if(additionalData!=null
 and additionalData.Data!=null
 and additionalData.Data.respondentCollection!=null
-and count(additionalData.Data.respondentCollection) &gt; 0
-and additionalData.Data.respondentCollection[1].value.et3Vetting!=null)
-then additionalData.Data.respondentCollection[1].value.et3Vetting.et3ContractClaimSection7
-else null</text>
+and count(additionalData.Data.respondentCollection) &gt; 0)
+then some item in additionalData.Data.respondentCollection satisfies (item.value.et3Vetting != null and item.value.et3Vetting.et3ContractClaimSection7 = true)
+else false</text>
         </inputExpression>
       </input>
       <input id="InputClause_0ezn9nq" label="Is ECC Reply Received" biodi:width="192">

--- a/src/main/resources/wa-task-initiation-employment-et_scotland.dmn
+++ b/src/main/resources/wa-task-initiation-employment-et_scotland.dmn
@@ -97,10 +97,9 @@ else false</text>
           <text>if(additionalData!=null
 and additionalData.Data!=null
 and additionalData.Data.respondentCollection!=null
-and count(additionalData.Data.respondentCollection) &gt; 0
-and additionalData.Data.respondentCollection[1].value.et3Vetting!=null)
-then additionalData.Data.respondentCollection[1].value.et3Vetting.et3IsThereAnEt3Response
-else null</text>
+and count(additionalData.Data.respondentCollection) &gt; 0)
+then some item in additionalData.Data.respondentCollection satisfies (item.value.et3Vetting != null and item.value.et3Vetting.et3IsThereAnEt3Response = true)
+else false</text>
         </inputExpression>
       </input>
       <input id="InputClause_0r1wqre" label="Is ECC">
@@ -108,10 +107,9 @@ else null</text>
           <text>if(additionalData!=null
 and additionalData.Data!=null
 and additionalData.Data.respondentCollection!=null
-and count(additionalData.Data.respondentCollection) &gt; 0
-and additionalData.Data.respondentCollection[1].value.et3Vetting!=null)
-then additionalData.Data.respondentCollection[1].value.et3Vetting.et3ContractClaimSection7
-else null</text>
+and count(additionalData.Data.respondentCollection) &gt; 0)
+then some item in additionalData.Data.respondentCollection satisfies (item.value.et3Vetting != null and item.value.et3Vetting.et3ContractClaimSection7 = true)
+else false</text>
         </inputExpression>
       </input>
       <input id="InputClause_1p24pi6" label="Is ECC Reply Received">

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestEW.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestEW.java
@@ -28,6 +28,9 @@ import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.DRAFT_
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.ET3_FORM_NOT_RECEIVED;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.ET3_FORM_RECEIVED_MORE;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.ET3_FORM_RECEIVED_ONCE;
+import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.ET3_RESPONSE_MIXED_ECC;
+import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.ET3_RESPONSE_SECOND_RESPONDENT_NO_ECC;
+import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.ET3_RESPONSE_SECOND_RESPONDENT_WITH_ECC;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.IS_ET3_RESPONSE_FALSE;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.IS_ET3_RESPONSE_TRUE;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.LISTAHEARING_PROCEED_LISTED;
@@ -529,6 +532,50 @@ class EmploymentTaskInitiationTestEW extends DmnDecisionTableBaseUnitTest {
                     HelperService.mapExpectedOutput(
                         "SendEt3Notification",
                         "Send ET3 Notification",
+                        "Processing"
+                    )
+                )
+            ),
+            // Second respondent has ET3, no ECC -> IC task must still be created
+            Arguments.of(
+                "et3Vetting",
+                "Accepted",
+                HelperService.mapAdditionalData(ET3_RESPONSE_SECOND_RESPONDENT_NO_ECC),
+                List.of(
+                    HelperService.mapExpectedOutput(
+                        "CompleteInitialConsideration",
+                        "Complete Initial Consideration",
+                        "Processing"
+                    ),
+                    HelperService.mapExpectedOutput(
+                        "SendEt3Notification",
+                        "Send ET3 Notification",
+                        "Processing"
+                    )
+                )
+            ),
+            // Second respondent has ET3 with ECC -> no IC task, refer ECC instead
+            Arguments.of(
+                "et3Vetting",
+                "Accepted",
+                HelperService.mapAdditionalData(ET3_RESPONSE_SECOND_RESPONDENT_WITH_ECC),
+                List.of(
+                    HelperService.mapExpectedOutput(
+                        "ReferEmployersContractClaim",
+                        "Refer Employer's Contract Claim",
+                        "Processing"
+                    )
+                )
+            ),
+            // Mix of respondent answers for ECC -> IC task must NOT be created
+            Arguments.of(
+                "et3Vetting",
+                "Accepted",
+                HelperService.mapAdditionalData(ET3_RESPONSE_MIXED_ECC),
+                List.of(
+                    HelperService.mapExpectedOutput(
+                        "ReferEmployersContractClaim",
+                        "Refer Employer's Contract Claim",
                         "Processing"
                     )
                 )

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestScot.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/dmn/EmploymentTaskInitiationTestScot.java
@@ -28,6 +28,9 @@ import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.DRAFT_
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.ET3_FORM_NOT_RECEIVED;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.ET3_FORM_RECEIVED_MORE;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.ET3_FORM_RECEIVED_ONCE;
+import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.ET3_RESPONSE_MIXED_ECC;
+import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.ET3_RESPONSE_SECOND_RESPONDENT_NO_ECC;
+import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.ET3_RESPONSE_SECOND_RESPONDENT_WITH_ECC;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.IS_ET3_RESPONSE_FALSE;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.IS_ET3_RESPONSE_TRUE;
 import static uk.gov.hmcts.et.taskconfiguration.utility.InitiationUtility.LISTAHEARING_PROCEED_LISTED;
@@ -531,6 +534,50 @@ class EmploymentTaskInitiationTestScot extends DmnDecisionTableBaseUnitTest {
                     HelperService.mapExpectedOutput(
                         "SendEt3Notification",
                         "Send ET3 Notification",
+                        "Processing"
+                    )
+                )
+            ),
+            // Second respondent has ET3, no ECC -> IC task must still be created
+            Arguments.of(
+                "et3Vetting",
+                "Accepted",
+                HelperService.mapAdditionalData(ET3_RESPONSE_SECOND_RESPONDENT_NO_ECC),
+                List.of(
+                    HelperService.mapExpectedOutput(
+                        "CompleteInitialConsideration",
+                        "Complete Initial Consideration",
+                        "Processing"
+                    ),
+                    HelperService.mapExpectedOutput(
+                        "SendEt3Notification",
+                        "Send ET3 Notification",
+                        "Processing"
+                    )
+                )
+            ),
+            // Second respondent has ET3 with ECC -> no IC task, refer ECC instead
+            Arguments.of(
+                "et3Vetting",
+                "Accepted",
+                HelperService.mapAdditionalData(ET3_RESPONSE_SECOND_RESPONDENT_WITH_ECC),
+                List.of(
+                    HelperService.mapExpectedOutput(
+                        "ReferEmployersContractClaim",
+                        "Refer Employer's Contract Claim",
+                        "Processing"
+                    )
+                )
+            ),
+            // Mix of respondent answers for ECC -> IC task must NOT be created
+            Arguments.of(
+                "et3Vetting",
+                "Accepted",
+                HelperService.mapAdditionalData(ET3_RESPONSE_MIXED_ECC),
+                List.of(
+                    HelperService.mapExpectedOutput(
+                        "ReferEmployersContractClaim",
+                        "Refer Employer's Contract Claim",
                         "Processing"
                     )
                 )

--- a/src/test/java/uk/gov/hmcts/et/taskconfiguration/utility/InitiationUtility.java
+++ b/src/test/java/uk/gov/hmcts/et/taskconfiguration/utility/InitiationUtility.java
@@ -119,6 +119,24 @@ public final class InitiationUtility {
         "\"respondentCollection\""
             +  ":[{\"value\":{\"et3Vetting\":{\"et3IsThereAnEt3Response\":false ,\"et3ContractClaimSection7\":true}}}]";
 
+    public static final String ET3_RESPONSE_SECOND_RESPONDENT_NO_ECC =
+        "\"respondentCollection\":["
+            + "{\"value\":{\"et3Vetting\":null}},"
+            + "{\"value\":{\"et3Vetting\":{\"et3IsThereAnEt3Response\":true,\"et3ContractClaimSection7\":false}}}"
+            + "]";
+
+    public static final String ET3_RESPONSE_SECOND_RESPONDENT_WITH_ECC =
+        "\"respondentCollection\":["
+            + "{\"value\":{\"et3Vetting\":null}},"
+            + "{\"value\":{\"et3Vetting\":{\"et3IsThereAnEt3Response\":true,\"et3ContractClaimSection7\":true}}}"
+            + "]";
+
+    public static final String ET3_RESPONSE_MIXED_ECC =
+        "\"respondentCollection\":["
+            + "{\"value\":{\"et3Vetting\":{\"et3IsThereAnEt3Response\":true,\"et3ContractClaimSection7\":false}}},"
+            + "{\"value\":{\"et3Vetting\":{\"et3IsThereAnEt3Response\":true,\"et3ContractClaimSection7\":true}}}"
+            + "]";
+
     public static final String LISTAHEARING_PROCEED_LISTED = "\"etICCanProceed\":true,"
         + "\"etICHearingAlreadyListed\":true,"
         + "\"etICHearingNotListedListUpdated\":["
@@ -158,14 +176,6 @@ public final class InitiationUtility {
         + "\"Seek comments on the video hearing\","
         + "\"UDL hearing\"]";
 
-    public static final String ET3_CONTRACT_CLAIM_SECTION_7 = "\"respondentCollection\":[{\"value\":{\"et3Vetting\":"
-        + "{\"et3ContractClaimSection7\":";
-
-
-    public static final String STRIKE_OUT_CLAIM =
-        "\"etInitialConsiderationRule27\": {"
-            + "\"etICRule27ClaimToBe\": \"Dismissed in full\""
-            + "}";
 
     public static final String SUBMISSION_REASON_CLAIMANT_AMEND =
         HelperService.createApplications("Amend my claim", "");


### PR DESCRIPTION
## [RET-5407](https://tools.hmcts.net/jira/browse/RET-5407)

## Summary

Updated the task initiation DMN for England/Wales and Scotland to fix the logic for creating the `CompleteInitialConsideration` (Initial Consideration) task when `et3Vetting` is completed.

## Changes

### DMNs updated
- `wa-task-initiation-employment-et_englandwales.dmn`
- `wa-task-initiation-employment-et_scotland.dmn`

The `Is There An Et3 Response` and `Is ECC` input expressions previously only checked `respondentCollection[1]` (the first respondent). They have been updated to use FEEL's `some item in ... satisfies` to evaluate all respondents.

**New logic:**
- `Is There An Et3 Response` = `true` if **any** respondent has `et3IsThereAnEt3Response = true`
- `Is ECC` = `true` if **any** respondent has `et3ContractClaimSection7 = true`

This means the IC task is now created correctly when:
- Any respondent on the case has submitted an ET3
- There is no ECC on the case (no respondent has an ECC claim)

### Tests updated
- `InitiationUtility` — added 3 new multi-respondent ET3 data constants
- `EmploymentTaskInitiationTestEW` — added 3 new `et3Vetting` scenarios
- `EmploymentTaskInitiationTestScot` — added 3 new `et3Vetting` scenarios

New scenarios cover:
1. Non-first respondent has ET3, no ECC → IC task created
2. Non-first respondent has ET3 with ECC → `ReferEmployersContractClaim` only
3. Mixed respondents (one with ECC, one without) → `ReferEmployersContractClaim` only; IC task must not fire